### PR TITLE
Functional tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
-  build:
+  tests:
     strategy:
       matrix:
         # We don't have a MSRV (yet?)
@@ -27,6 +27,9 @@ jobs:
         run: cargo build --verbose --color always
       - name: Test on Rust ${{ matrix.toolchain }}
         run: cargo test --verbose --color always
+      - name: Functional tests
+        if: matrix.os == 'ubuntu-latest'
+        run: ./contrib/ci-functional-tests.sh
 
   grcov:
     runs-on: ubuntu-latest
@@ -49,6 +52,7 @@ jobs:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          run: ./contrib/ci-functional-tests.sh
 
       - name: Gather coverage data
         id: coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,6 @@ jobs:
         # We don't have a MSRV (yet?)
         toolchain:
           - stable
-          - beta
-          - nightly
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tags
 target/
+__pycache__

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 [[package]]
 name = "jsonrpc"
 version = "0.11.0"
-source = "git+https://github.com/apoelstra/rust-jsonrpc?branch=2020-09-basic-client#451f07fefc437215bebe737ccfed016e324e41ad"
+source = "git+https://github.com/apoelstra/rust-jsonrpc?branch=2020-09-basic-client#328a6f3ebb0ddc3b2be0322d965ef613278625a3"
 dependencies = [
  "base64-compat",
  "http",

--- a/contrib/ci-functional-tests.sh
+++ b/contrib/ci-functional-tests.sh
@@ -1,0 +1,19 @@
+set -xe
+
+cargo build
+sudo apt update
+sudo apt install python3 python3-pip python3-venv libsqlite3-dev build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 libevent-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev
+
+# FIXME: dl it from bitcoincore.org post branch-off
+git clone https://github.com/bitcoin/bitcoin && cd bitcoin
+./contrib/install_db4.sh `pwd`
+./autogen.sh
+export BDB_PREFIX="`pwd`/db4"
+./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" --without-gui --disable-tests --enable-c++17
+make -j4 && sudo make install
+cd ..
+
+python3 -m venv venv
+. venv/bin/activate
+pip install -r tests/requirements.txt
+pytest -vvv -n2 tests/

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,6 +175,8 @@ pub struct Config {
     pub unvault_csv: u32,
     /// An optional custom data directory
     pub data_dir: Option<PathBuf>,
+    /// Whether to daemonize the process
+    pub daemon: Option<bool>,
     // TODO: sync server address
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,12 +89,15 @@ fn main() {
         process::exit(1);
     });
 
-    let mut daemon = Daemonize::default();
-    // TODO: Make this configurable for inits
-    daemon.pid_file = Some(revaultd.pid_file());
-    daemon.doit().unwrap_or_else(|e| {
-        eprintln!("Error daemonizing: {}", e);
-        process::exit(1);
-    });
+    if revaultd.daemon {
+        let mut daemon = Daemonize::default();
+        // TODO: Make this configurable for inits
+        daemon.pid_file = Some(revaultd.pid_file());
+        daemon.doit().unwrap_or_else(|e| {
+            eprintln!("Error daemonizing: {}", e);
+            process::exit(1);
+        });
+        println!("Started revaultd daemon");
+    }
     daemon_main(revaultd);
 }

--- a/src/revaultd.rs
+++ b/src/revaultd.rs
@@ -99,6 +99,8 @@ pub struct Vault {
 pub struct RevaultD {
     /// We store all our data in one place, that's here.
     pub data_dir: PathBuf,
+    /// Should we run as a daemon? (Default: yes)
+    pub daemon: bool,
 
     /// Everything we need to know to talk to bitcoind
     pub bitcoind_config: BitcoindConfig,
@@ -177,11 +179,17 @@ impl RevaultD {
             }
         }
 
+        let daemon = match config.daemon {
+            Some(false) => false,
+            _ => true,
+        };
+
         Ok(RevaultD {
             vault_descriptor,
             unvault_descriptor,
             unvault_cpfp_descriptor,
             data_dir,
+            daemon,
             bitcoind_config: config.bitcoind_config,
             ourselves: config.ourselves,
             // Will be updated by the database

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+## Revaultd blackbox tests
+
+Here we test `revaultd` by starting it on a regression testing Bitcoin network,
+and by then talking to it as an user would, from the outside.
+
+Python scripts are used for the automation, and specifically the `pytest` framework
+and its fixtures.
+
+Credits: some (a lot) of the fixtures and utilities originated from the great
+[C-lightning test framework](https://github.com/ElementsProject/lightning/tree/master/contrib/pyln-testing)
+and adapted.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,112 @@
+"""
+Most of the code here is stolen from C-lightning's test suite. This is surely
+Rusty Russell or Christian Decker who wrote most of this (I'd put some sats on
+cdecker), so credits to them ! (MIT licensed)
+"""
+from bitcoin.core import COIN
+from decimal import Decimal
+from utils import BitcoinD, wait_for
+
+import logging
+import os
+import pytest
+import shutil
+import tempfile
+
+__attempts = {}
+
+
+@pytest.fixture(scope="session")
+def test_base_dir():
+    d = os.getenv("TEST_DIR", "/tmp")
+
+    directory = tempfile.mkdtemp(prefix='revaultd-tests-', dir=d)
+    print("Running tests in {}".format(directory))
+
+    yield directory
+
+    if os.listdir(directory) == []:
+        shutil.rmtree(directory)
+
+
+@pytest.fixture
+def directory(request, test_base_dir, test_name):
+    """Return a per-test specific directory.
+
+    This makes a unique test-directory even if a test is rerun multiple times.
+
+    """
+    global __attempts
+    # Auto set value if it isn't in the dict yet
+    __attempts[test_name] = __attempts.get(test_name, 0) + 1
+    directory = os.path.join(test_base_dir,
+                             "{}_{}".format(test_name, __attempts[test_name]))
+    request.node.has_errors = False
+
+    yield directory
+
+    # This uses the status set in conftest.pytest_runtest_makereport to
+    # determine whether we succeeded or failed. Outcome can be None if the
+    # failure occurs during the setup phase, hence the use to getattr instead
+    # of accessing it directly.
+    rep_call = getattr(request.node, 'rep_call', None)
+    outcome = 'passed' if rep_call is None else rep_call.outcome
+    failed = not outcome or outcome != 'passed'
+
+    if not failed:
+        shutil.rmtree(directory)
+    else:
+        logging.debug("Test execution failed, leaving the test directory {}"
+                      " intact.".format(directory))
+
+
+@pytest.fixture
+def test_name(request):
+    yield request.function.__name__
+
+
+@pytest.fixture
+def bitcoind(directory):
+    bitcoind = BitcoinD(bitcoin_dir=directory)
+    bitcoind.startup()
+
+    while bitcoind.rpc.getbalance() < 50:
+        bitcoind.rpc.generatetoaddress(1, bitcoind.getnewaddress())
+
+    yield bitcoind
+
+    bitcoind.cleanup()
+
+
+@pytest.fixture
+def bitcoinds(directory):
+    # FIXME: do it in a less hacky manner
+    n_bitcoind = 5
+    bitcoinds = [BitcoinD(bitcoin_dir="{}/{}".format(directory, i))
+                 for i in range(n_bitcoind)]
+
+    for bitcoind in bitcoinds:
+        bitcoind.startup()
+
+    # Connect everyone..
+    for bit in bitcoinds:
+        for i in range(len(bitcoinds)):
+            bit.rpc.addnode("127.0.0.1:{}".format(bitcoinds[i]
+                                                  .p2pport), "add")
+
+    wait_for(lambda: all(bit.rpc.getconnectioncount() > 3
+                         for bit in bitcoinds))
+
+    # Hand some funds to everyone (10 utxos)
+    rounds = 111 // n_bitcoind + 1
+    for _ in range(rounds):
+        for bitcoind in bitcoinds:
+            bitcoind.rpc.generatetoaddress(1, bitcoind.rpc.getnewaddress())
+            blockcount = bitcoind.rpc.getblockcount()
+            wait_for(lambda: all(bit.rpc.getblockcount() == blockcount
+                                 for bit in bitcoinds))
+
+    yield bitcoinds
+
+    for bitcoind in bitcoinds:
+        bitcoind.cleanup()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,7 +5,7 @@ cdecker), so credits to them ! (MIT licensed)
 """
 from bitcoin.core import COIN
 from decimal import Decimal
-from utils import BitcoinD, wait_for
+from utils import BitcoinD, RevaultD, wait_for
 
 import logging
 import os
@@ -71,3 +71,46 @@ def bitcoind(directory):
     yield bitcoind
 
     bitcoind.cleanup()
+
+
+@pytest.fixture
+def revaultd_stakeholder(bitcoind, test_base_dir):
+    datadir = os.path.join(test_base_dir, "revaultd")
+    os.makedirs(datadir, exist_ok=True)
+    ourselves = {
+        "stakeholder_xpub": "xpub6AP3nZhB34Zoan3KCL9bAdnwNHdzMbskLudpbchwTfkHwnNDXYf1769gzozjgzDNUF7iwa5nCdhE5byrcx5PDKFCUDByeuqiHa382EKhcay",
+    }
+    managers = [
+        {
+            "xpub": "xpub6AtVcKWPpZ9t3Aa3VvzWid1dzJFeXPfNntPbkGsYjNrp7uhXpzSL5QVMCmaHqUzbVUGENEwbBbzF9E8emTxQeP3AzbMjfzvwSDkwUrxg2G4",
+        },
+        {
+            "xpub": "xpub6AMXQWzNN9GSrWk5SeKdEUK6Ntha87BBtprp95EGSsLiMkUedYcHh53P3J1frsnMqRSssARq6EdRnAJmizJMaBqxCrA3MVGjV7d9wNQAEtm",
+        },
+    ]
+    stakeholders = [
+        {
+            "xpub": "xpub6BHATNyFVsBD8MRygTsv2q9WFTJzEB3o6CgJK7sjopcB286bmWFkNYm6kK5fzVe2gk4mJrSK5isFSFommNDST3RYJWSzrAe9V4bEzboHqnA",
+            "cosigner_key": "02644cf9e2b78feb0a751e50502f530a4cbd0bbda3020779605391e71654dd66c2",
+        },
+        {
+            "xpub": "xpub6AP3nZhB34Zoan3KCL9bAdnwNHdzMbskLudpbchwTfkHwnNDXYf1769gzozjgzDNUF7iwa5nCdhE5byrcx5PDKFCUDByeuqiHa382EKhcay",
+            "cosigner_key": "03ced55d1208bd8c6b42b11e29baa577711cae831b3a1296607c5e5d3ed365f49c",
+        },
+        {
+            "xpub": "xpub6AUkrYoAoySUXnEbspdqL7dJ5qE4n5wTDAXb22tzNaU9cKqpeE6Tjvh5gkXECrX8bGM2Ndgk3HYYVmD7m3NyHxS74NRi1cuq9ddxmhG8RxP",
+            "cosigner_key": "026237f655f3bf45fd6b7aa00e91c2603d6155f1cc001e40f5e47662d965c4c779",
+        },
+        {
+            "xpub": "xpub6AL6oiHLkP5bDMry27vH7uethb1g8iTysk5MZJvNe1yBv5fedvqqgiaPS2riWCiu4o3H8xinEVdQ5zz8pZKH1RtjTbdQyxHsMMCBrp2PP8S",
+            "cosigner_key": "030a3cbcfbfdf7122fe7fa830354c956ea6595f2dbde23286f03bc1ec0c1685ca3",
+        },
+    ]
+    csv = 35
+    revaultd = RevaultD(datadir, ourselves, stakeholders, managers, csv,
+                        bitcoind)
+    revaultd.start()
+
+    yield revaultd
+
+    revaultd.cleanup()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -73,42 +73,62 @@ def bitcoind(directory):
     bitcoind.cleanup()
 
 
+MOCK_MANAGERS = [
+    {
+        "xpub": "xpub6AtVcKWPpZ9t3Aa3VvzWid1dzJFeXPfNntPbkGsYjNrp7uhXpzSL5QVMCmaHqUzbVUGENEwbBbzF9E8emTxQeP3AzbMjfzvwSDkwUrxg2G4",
+    },
+    {
+        "xpub": "xpub6AMXQWzNN9GSrWk5SeKdEUK6Ntha87BBtprp95EGSsLiMkUedYcHh53P3J1frsnMqRSssARq6EdRnAJmizJMaBqxCrA3MVGjV7d9wNQAEtm",
+    },
+]
+
+MOCK_STAKEHOLDERS = [
+    {
+        "xpub": "xpub6BHATNyFVsBD8MRygTsv2q9WFTJzEB3o6CgJK7sjopcB286bmWFkNYm6kK5fzVe2gk4mJrSK5isFSFommNDST3RYJWSzrAe9V4bEzboHqnA",
+        "cosigner_key": "02644cf9e2b78feb0a751e50502f530a4cbd0bbda3020779605391e71654dd66c2",
+    },
+    {
+        "xpub": "xpub6AP3nZhB34Zoan3KCL9bAdnwNHdzMbskLudpbchwTfkHwnNDXYf1769gzozjgzDNUF7iwa5nCdhE5byrcx5PDKFCUDByeuqiHa382EKhcay",
+        "cosigner_key": "03ced55d1208bd8c6b42b11e29baa577711cae831b3a1296607c5e5d3ed365f49c",
+    },
+    {
+        "xpub": "xpub6AUkrYoAoySUXnEbspdqL7dJ5qE4n5wTDAXb22tzNaU9cKqpeE6Tjvh5gkXECrX8bGM2Ndgk3HYYVmD7m3NyHxS74NRi1cuq9ddxmhG8RxP",
+        "cosigner_key": "026237f655f3bf45fd6b7aa00e91c2603d6155f1cc001e40f5e47662d965c4c779",
+    },
+    {
+        "xpub": "xpub6AL6oiHLkP5bDMry27vH7uethb1g8iTysk5MZJvNe1yBv5fedvqqgiaPS2riWCiu4o3H8xinEVdQ5zz8pZKH1RtjTbdQyxHsMMCBrp2PP8S",
+        "cosigner_key": "030a3cbcfbfdf7122fe7fa830354c956ea6595f2dbde23286f03bc1ec0c1685ca3",
+    },
+]
+
+
 @pytest.fixture
 def revaultd_stakeholder(bitcoind, test_base_dir):
     datadir = os.path.join(test_base_dir, "revaultd")
     os.makedirs(datadir, exist_ok=True)
     ourselves = {
-        "stakeholder_xpub": "xpub6AP3nZhB34Zoan3KCL9bAdnwNHdzMbskLudpbchwTfkHwnNDXYf1769gzozjgzDNUF7iwa5nCdhE5byrcx5PDKFCUDByeuqiHa382EKhcay",
+        "stakeholder_xpub": MOCK_STAKEHOLDERS[0]["xpub"],
     }
-    managers = [
-        {
-            "xpub": "xpub6AtVcKWPpZ9t3Aa3VvzWid1dzJFeXPfNntPbkGsYjNrp7uhXpzSL5QVMCmaHqUzbVUGENEwbBbzF9E8emTxQeP3AzbMjfzvwSDkwUrxg2G4",
-        },
-        {
-            "xpub": "xpub6AMXQWzNN9GSrWk5SeKdEUK6Ntha87BBtprp95EGSsLiMkUedYcHh53P3J1frsnMqRSssARq6EdRnAJmizJMaBqxCrA3MVGjV7d9wNQAEtm",
-        },
-    ]
-    stakeholders = [
-        {
-            "xpub": "xpub6BHATNyFVsBD8MRygTsv2q9WFTJzEB3o6CgJK7sjopcB286bmWFkNYm6kK5fzVe2gk4mJrSK5isFSFommNDST3RYJWSzrAe9V4bEzboHqnA",
-            "cosigner_key": "02644cf9e2b78feb0a751e50502f530a4cbd0bbda3020779605391e71654dd66c2",
-        },
-        {
-            "xpub": "xpub6AP3nZhB34Zoan3KCL9bAdnwNHdzMbskLudpbchwTfkHwnNDXYf1769gzozjgzDNUF7iwa5nCdhE5byrcx5PDKFCUDByeuqiHa382EKhcay",
-            "cosigner_key": "03ced55d1208bd8c6b42b11e29baa577711cae831b3a1296607c5e5d3ed365f49c",
-        },
-        {
-            "xpub": "xpub6AUkrYoAoySUXnEbspdqL7dJ5qE4n5wTDAXb22tzNaU9cKqpeE6Tjvh5gkXECrX8bGM2Ndgk3HYYVmD7m3NyHxS74NRi1cuq9ddxmhG8RxP",
-            "cosigner_key": "026237f655f3bf45fd6b7aa00e91c2603d6155f1cc001e40f5e47662d965c4c779",
-        },
-        {
-            "xpub": "xpub6AL6oiHLkP5bDMry27vH7uethb1g8iTysk5MZJvNe1yBv5fedvqqgiaPS2riWCiu4o3H8xinEVdQ5zz8pZKH1RtjTbdQyxHsMMCBrp2PP8S",
-            "cosigner_key": "030a3cbcfbfdf7122fe7fa830354c956ea6595f2dbde23286f03bc1ec0c1685ca3",
-        },
-    ]
     csv = 35
-    revaultd = RevaultD(datadir, ourselves, stakeholders, managers, csv,
-                        bitcoind)
+    revaultd = RevaultD(datadir, ourselves, MOCK_STAKEHOLDERS, MOCK_MANAGERS,
+                        csv, bitcoind)
+    revaultd.start()
+
+    yield revaultd
+
+    revaultd.cleanup()
+
+
+@pytest.fixture
+def revaultd_manager(bitcoind, test_base_dir):
+    datadir = os.path.join(test_base_dir, "revaultd")
+    os.makedirs(datadir, exist_ok=True)
+    ourselves = {
+        "manager_xpub": MOCK_MANAGERS[0]["xpub"],
+    }
+    csv = 35
+    revaultd = RevaultD(datadir, ourselves, MOCK_STAKEHOLDERS, MOCK_MANAGERS,
+                        csv, bitcoind)
     revaultd.start()
 
     yield revaultd

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,5 @@
+python-bitcoinlib==0.11.0
+pytest==5.3.5
+pytest-xdist==1.31.0
+pytest-timeout==1.3.4
+ephemeral_port_reserve==1.1.1

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,4 @@
+from fixtures import bitcoind, directory, test_base_dir, test_name
+
+def test_framework(bitcoind):
+    pass

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,7 @@
-from fixtures import bitcoind, directory, test_base_dir, test_name
+from fixtures import (
+    revaultd_stakeholder, bitcoind, directory, test_base_dir, test_name
+)
 
-def test_framework(bitcoind):
+def test_revaultd_stakeholder_starts(revaultd_stakeholder):
+    # The fixture waits until "revaultd started" so we fine here
     pass

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,7 +1,12 @@
 from fixtures import (
-    revaultd_stakeholder, bitcoind, directory, test_base_dir, test_name
+    revaultd_stakeholder, revaultd_manager, bitcoind, directory, test_base_dir,
+    test_name
 )
 
 def test_revaultd_stakeholder_starts(revaultd_stakeholder):
+    # The fixture waits until "revaultd started" so we fine here
+    pass
+
+def test_revaultd_manager_starts(revaultd_manager):
     # The fixture waits until "revaultd started" so we fine here
     pass

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,404 @@
+"""
+Most of the code here is stolen from C-lightning's test suite. This is surely
+Rusty Russell or Christian Decker who wrote most of this (I'd put some sats on
+cdecker), so credits to them ! (MIT licensed)
+"""
+from bip32 import BIP32
+from bitcoin.rpc import RawProxy as BitcoinProxy
+from bitcoin.wallet import CKey
+from decimal import Decimal
+from ephemeral_port_reserve import reserve
+from revault import Vault, SigServer, CosigningServer
+
+import bitcoin
+import logging
+import os
+import re
+import subprocess
+import threading
+import time
+
+BITCOIND_CONFIG = {
+    "regtest": 1,
+    "rpcuser": "rpcuser",
+    "rpcpassword": "rpcpass",
+    "addresstype": "bech32",
+}
+
+
+TIMEOUT = int(os.getenv("TIMEOUT", 100))
+
+
+def wait_for(success, timeout=TIMEOUT):
+    start_time = time.time()
+    interval = 0.25
+    while not success() and time.time() < start_time + timeout:
+        time.sleep(interval)
+        interval *= 2
+        if interval > 5:
+            interval = 5
+    if time.time() > start_time + timeout:
+        raise ValueError("Error waiting for {}", success)
+
+
+def write_config(filename, opts, regtest_opts=None, section_name='regtest'):
+    with open(filename, 'w') as f:
+        for k, v in opts.items():
+            f.write("{}={}\n".format(k, v))
+        if regtest_opts:
+            f.write("[{}]\n".format(section_name))
+            for k, v in regtest_opts.items():
+                f.write("{}={}\n".format(k, v))
+
+
+class TailableProc(object):
+    """A monitorable process that we can start, stop and tail.
+
+    This is the base class for the daemons. It allows us to directly
+    tail the processes and react to their output.
+    """
+
+    def __init__(self, outputDir=None, verbose=True):
+        self.logs = []
+        self.logs_cond = threading.Condition(threading.RLock())
+        self.env = os.environ.copy()
+        self.running = False
+        self.proc = None
+        self.outputDir = outputDir
+        self.logsearch_start = 0
+
+        # Should we be logging lines we read from stdout?
+        self.verbose = verbose
+
+        # A filter function that'll tell us whether to filter out the line (not
+        # pass it to the log matcher and not print it to stdout).
+        self.log_filter = lambda line: False
+
+    def start(self, stdin=None, stdout=None, stderr=None):
+        """Start the underlying process and start monitoring it.
+        """
+        logging.debug("Starting '%s'", " ".join(self.cmd_line))
+        self.proc = subprocess.Popen(self.cmd_line,
+                                     stdin=stdin,
+                                     stdout=stdout if stdout
+                                     else subprocess.PIPE,
+                                     stderr=stderr,
+                                     env=self.env)
+        self.thread = threading.Thread(target=self.tail)
+        self.thread.daemon = True
+        self.thread.start()
+        self.running = True
+
+    def save_log(self):
+        if self.outputDir:
+            logpath = os.path.join(self.outputDir, 'log')
+            with open(logpath, 'w') as f:
+                for l in self.logs:
+                    f.write(l + '\n')
+
+    def stop(self, timeout=10):
+        self.save_log()
+        self.proc.terminate()
+
+        # Now give it some time to react to the signal
+        rc = self.proc.wait(timeout)
+
+        if rc is None:
+            self.proc.kill()
+
+        self.proc.wait()
+        self.thread.join()
+
+        return self.proc.returncode
+
+    def kill(self):
+        """Kill process without giving it warning."""
+        self.proc.kill()
+        self.proc.wait()
+        self.thread.join()
+
+    def tail(self):
+        """Tail the stdout of the process and remember it.
+
+        Stores the lines of output produced by the process in
+        self.logs and signals that a new line was read so that it can
+        be picked up by consumers.
+        """
+        for line in iter(self.proc.stdout.readline, ''):
+            if len(line) == 0:
+                break
+            if self.log_filter(line.decode('ASCII')):
+                continue
+            if self.verbose:
+                logging.debug("%s: %s", self.prefix, line.decode().rstrip())
+            with self.logs_cond:
+                self.logs.append(str(line.rstrip()))
+                self.logs_cond.notifyAll()
+        self.running = False
+        self.proc.stdout.close()
+        if self.proc.stderr:
+            self.proc.stderr.close()
+
+    def is_in_log(self, regex, start=0):
+        """Look for `regex` in the logs."""
+
+        ex = re.compile(regex)
+        for l in self.logs[start:]:
+            if ex.search(l):
+                logging.debug("Found '%s' in logs", regex)
+                return l
+
+        logging.debug("Did not find '%s' in logs", regex)
+        return None
+
+    def wait_for_logs(self, regexs, timeout=TIMEOUT):
+        """Look for `regexs` in the logs.
+
+        We tail the stdout of the process and look for each regex in `regexs`,
+        starting from last of the previous waited-for log entries (if any).  We
+        fail if the timeout is exceeded or if the underlying process
+        exits before all the `regexs` were found.
+
+        If timeout is None, no time-out is applied.
+        """
+        logging.debug("Waiting for {} in the logs".format(regexs))
+        exs = [re.compile(r) for r in regexs]
+        start_time = time.time()
+        pos = self.logsearch_start
+        while True:
+            if timeout is not None and time.time() > start_time + timeout:
+                print("Time-out: can't find {} in logs".format(exs))
+                for r in exs:
+                    if self.is_in_log(r):
+                        print("({} was previously in logs!)".format(r))
+                raise TimeoutError('Unable to find "{}" in logs.'.format(exs))
+            elif not self.running:
+                raise ValueError('Process died while waiting for logs')
+
+            with self.logs_cond:
+                if pos >= len(self.logs):
+                    self.logs_cond.wait(1)
+                    continue
+
+                for r in exs.copy():
+                    self.logsearch_start = pos + 1
+                    if r.search(self.logs[pos]):
+                        logging.debug("Found '%s' in logs", r)
+                        exs.remove(r)
+                        break
+                if len(exs) == 0:
+                    return self.logs[pos]
+                pos += 1
+
+    def wait_for_log(self, regex, timeout=TIMEOUT):
+        """Look for `regex` in the logs.
+
+        Convenience wrapper for the common case of only seeking a single entry.
+        """
+        return self.wait_for_logs([regex], timeout)
+
+
+class SimpleBitcoinProxy:
+    """Wrapper for BitcoinProxy to reconnect.
+
+    Long wait times between calls to the Bitcoin RPC could result in
+    `bitcoind` closing the connection, so here we just create
+    throwaway connections. This is easier than to reach into the RPC
+    library to close, reopen and reauth upon failure.
+    """
+    def __init__(self, btc_conf_file, *args, **kwargs):
+        self.__btc_conf_file__ = btc_conf_file
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            # Python internal stuff
+            raise AttributeError
+
+        # Create a callable to do the actual call
+        proxy = BitcoinProxy(btc_conf_file=self.__btc_conf_file__)
+
+        def f(*args):
+            return proxy._call(name, *args)
+
+        # Make debuggers show <function bitcoin.rpc.name> rather than <function
+        # bitcoin.rpc.<lambda>>
+        f.__name__ = name
+        return f
+
+
+class BitcoinD(TailableProc):
+    def __init__(self, bitcoin_dir="/tmp/bitcoind-test", rpcport=None):
+        TailableProc.__init__(self, bitcoin_dir, verbose=False)
+
+        if rpcport is None:
+            rpcport = reserve()
+
+        self.bitcoin_dir = bitcoin_dir
+        self.rpcport = rpcport
+        self.p2pport = reserve()
+        self.prefix = 'bitcoind'
+
+        regtestdir = os.path.join(bitcoin_dir, 'regtest')
+        if not os.path.exists(regtestdir):
+            os.makedirs(regtestdir)
+
+        self.cmd_line = [
+            'bitcoind',
+            '-datadir={}'.format(bitcoin_dir),
+            '-printtoconsole',
+            '-server',
+            '-logtimestamps',
+            '-txindex',
+            '-addresstype=bech32',
+            '-rpcthreads=16',
+        ]
+        # For up to and including 0.16.1, this needs to be in main section.
+        BITCOIND_CONFIG['rpcport'] = rpcport
+        # For after 0.16.1 (eg. 3f398d7a17f136cd4a67998406ca41a124ae2966), this
+        # needs its own [regtest] section.
+        BITCOIND_REGTEST = {
+            'port': self.p2pport,
+            'rpcport': rpcport,
+            'debug': 1,
+            'fallbackfee': Decimal(1000) / bitcoin.core.COIN,
+        }
+        self.conf_file = os.path.join(bitcoin_dir, 'bitcoin.conf')
+        write_config(self.conf_file, BITCOIND_CONFIG, BITCOIND_REGTEST)
+        self.rpc = SimpleBitcoinProxy(btc_conf_file=self.conf_file)
+        self.proxies = []
+
+    def start(self):
+        TailableProc.start(self)
+        self.wait_for_log("Done loading", timeout=TIMEOUT)
+
+        logging.info("BitcoinD started")
+
+    def stop(self):
+        for p in self.proxies:
+            p.stop()
+        self.rpc.stop()
+        return TailableProc.stop(self)
+
+    # wait_for_mempool can be used to wait for the mempool before generating
+    # blocks:
+    # True := wait for at least 1 transation
+    # int > 0 := wait for at least N transactions
+    # 'tx_id' := wait for one transaction id given as a string
+    # ['tx_id1', 'tx_id2'] := wait until all of the specified transaction IDs
+    def generate_block(self, numblocks=1, wait_for_mempool=0):
+        if wait_for_mempool:
+            if isinstance(wait_for_mempool, str):
+                wait_for_mempool = [wait_for_mempool]
+            if isinstance(wait_for_mempool, list):
+                wait_for(lambda: all(txid in self.rpc.getrawmempool()
+                                     for txid in wait_for_mempool))
+            else:
+                wait_for(lambda: len(self.rpc.getrawmempool())
+                         >= wait_for_mempool)
+        # As of 0.16, generate() is removed; use generatetoaddress.
+        addr = self.rpc.getnewaddress()
+        return self.rpc.generatetoaddress(numblocks, addr)
+
+    def simple_reorg(self, height, shift=0):
+        """
+        Reorganize chain by creating a fork at height=[height] and re-mine all
+        mempool transactions into [height + shift], where shift >= 0. Returns
+        hashes of generated blocks.
+
+        Note that tx's that become invalid at [height] (because coin maturity,
+        locktime etc.) are removed from mempool. The length of the new chain
+        will be original + 1 OR original + [shift], whichever is larger.
+
+        For example: to push tx's backward from height h1 to h2 < h1,
+        use [height]=h2.
+
+        Or to change the txindex of tx's at height h1:
+        1. A block at height h2 < h1 should contain a non-coinbase tx that can
+            be pulled forward to h1.
+        2. Set [height]=h2 and [shift]= h1-h2
+        """
+        hashes = []
+        fee_delta = 1000000
+        orig_len = self.rpc.getblockcount()
+        old_hash = self.rpc.getblockhash(height)
+        if height + shift > orig_len:
+            final_len = height + shift
+        else:
+            final_len = 1 + orig_len
+        # TODO: raise error for insane args?
+
+        self.rpc.invalidateblock(old_hash)
+        self.wait_for_log(r'InvalidChainFound: invalid block=.*  height={}'
+                          .format(height))
+        memp = self.rpc.getrawmempool()
+
+        if shift == 0:
+            hashes += self.generate_block(1 + final_len - height)
+        else:
+            for txid in memp:
+                # lower priority (to effective feerate=0) so they are not mined
+                self.rpc.prioritisetransaction(txid, None, -fee_delta)
+            hashes += self.generate_block(shift)
+
+            for txid in memp:
+                # restore priority so they are mined
+                self.rpc.prioritisetransaction(txid, None, fee_delta)
+            hashes += self.generate_block(1 + final_len - (height + shift))
+        self.wait_for_log(r'UpdateTip: new best=.* height={}'
+                          .format(final_len))
+        return hashes
+
+    def getnewaddress(self):
+        return self.rpc.getnewaddress()
+
+    def pay_to(self, address, amount):
+        self.generate_block(1)
+        # So that we can boutique-compute fees in the tests by assuming we work
+        # with 50 * 10**8 sats outputs.
+        addr = self.getnewaddress()
+        txid = self.rpc.sendtoaddress(addr, 50)
+        self.generate_block(1, wait_for_mempool=str(txid))
+        txin = self.rpc.listunspent(None, None, [addr], None, None)[-1]
+        tx = self.rpc.createrawtransaction([
+            {"txid": txin["txid"],
+             "vout": txin["vout"],
+             "amount": float(txin["amount"])}
+        ], [
+            {address: float(amount)}
+        ])
+        tx = self.rpc.signrawtransactionwithwallet(tx)["hex"]
+        txid = self.rpc.sendrawtransaction(tx)
+        self.generate_block(1, wait_for_mempool=str(txid))
+        return txid
+
+    def send_tx(self, hex_tx):
+        txid = self.rpc.sendrawtransaction(hex_tx)
+        self.generate_block(1, wait_for_mempool=str(txid))
+
+    def has_utxo(self, address):
+        """Test that we possess an utxo paying to this address."""
+        if address in [utxo["address"] for utxo in self.rpc.listunspent()]:
+            return True
+        return False
+
+    def startup(self):
+        try:
+            self.start()
+        except Exception:
+            self.stop()
+            raise
+
+        info = self.rpc.getnetworkinfo()
+
+        if info['version'] < 160000:
+            self.rpc.stop()
+            raise ValueError("bitcoind is too old. At least version 16000"
+                             " (v0.16.0) is needed, current version is {}"
+                             .format(info['version']))
+
+    def cleanup(self):
+        try:
+            self.stop()
+        except Exception:
+            self.proc.kill()
+        self.proc.wait()


### PR DESCRIPTION
Based on #19.

This implements the backbone of functional tests in Python using `pytest` and directories in `/tmp/`. Just small fixtures for now, but i eventually want something like a `RevaultFactory` to be able to do something like:
```python
stakeholders = revault_factory.get_stakeholders(5)
managers = revault_factory.get_managers(3)
```

I hardcoded the xpub, but eventually we'll generate keys using [`bip32`](https://github.com/darosior/python-bip32).

Still need to find a way to make GA run functional tests.