### PR TITLE
feat: add lib.rs for external use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod bitcoind;
+pub mod config;
+pub mod database;
+pub mod revaultd;


### PR DESCRIPTION
In order to use revaultd as an external library.