### PR TITLE
refac: move daemon_main to daemon::start

### DIFF
--- a/src/bitcoind/actions.rs
+++ b/src/bitcoind/actions.rs
@@ -13,7 +13,7 @@ use revault_tx::{
 };
 
 use std::{
-    process, thread,
+    thread,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -223,37 +223,39 @@ fn maybe_load_wallet(revaultd: &RevaultD, bitcoind: &BitcoinD) -> Result<(), Bit
 
 /// Connects to, sanity checks, and wait for bitcoind to be synced.
 /// Called at startup, will log and abort on error.
-pub fn setup_bitcoind(revaultd: &mut RevaultD) -> BitcoinD {
-    let bitcoind = BitcoinD::new(&revaultd.bitcoind_config).unwrap_or_else(|e| {
+pub fn setup_bitcoind(revaultd: &mut RevaultD) -> Result<BitcoinD, BitcoindError> {
+    let bitcoind = BitcoinD::new(&revaultd.bitcoind_config).map_err(|e| {
         log::error!("Could not connect to bitcoind: {}", e.to_string());
-        process::exit(1);
-    });
+        e
+    })?;
 
-    bitcoind_sanity_checks(&bitcoind, &revaultd.bitcoind_config).unwrap_or_else(|e| {
+    bitcoind_sanity_checks(&bitcoind, &revaultd.bitcoind_config).map_err(|e| {
         // FIXME: handle warming up
         log::error!("Error checking bitcoind: {}", e.to_string());
-        process::exit(1);
-    });
+        e
+    })?;
 
-    wait_for_bitcoind_synced(&bitcoind, &revaultd.bitcoind_config).unwrap_or_else(|e| {
+    wait_for_bitcoind_synced(&bitcoind, &revaultd.bitcoind_config).map_err(|e| {
         log::error!("Error while updating tip: {}", e.to_string());
-        process::exit(1);
-    });
+        e
+    })?;
 
-    unload_all_wallets(&bitcoind).unwrap_or_else(|e| {
+    unload_all_wallets(&bitcoind).map_err(|e| {
         log::error!("Unloading existing wallets: {}", e.to_string());
-        process::exit(1);
-    });
-    maybe_create_wallet(revaultd, &bitcoind).unwrap_or_else(|e| {
-        log::error!("Error while creating wallet: {}", e.to_string());
-        process::exit(1);
-    });
-    maybe_load_wallet(&revaultd, &bitcoind).unwrap_or_else(|e| {
-        log::error!("Error while loading wallet: {}", e.to_string());
-        process::exit(1);
-    });
+        e
+    })?;
 
-    bitcoind
+    maybe_create_wallet(revaultd, &bitcoind).map_err(|e| {
+        log::error!("Error while creating wallet: {}", e.to_string());
+        e
+    })?;
+
+    maybe_load_wallet(&revaultd, &bitcoind).map_err(|e| {
+        log::error!("Error while loading wallet: {}", e.to_string());
+        e
+    })?;
+
+    Ok(bitcoind)
 }
 
 fn tx_from_hex(hex: &str) -> Result<Transaction, BitcoindError> {

--- a/src/bitcoind/mod.rs
+++ b/src/bitcoind/mod.rs
@@ -9,3 +9,5 @@ impl std::fmt::Display for BitcoindError {
         write!(f, "Bitcoind error: {}", self.0)
     }
 }
+
+impl std::error::Error for BitcoindError {}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,29 @@
+use crate::{
+    bitcoind::actions::{bitcoind_main_loop, setup_bitcoind},
+    database::actions::setup_db,
+    revaultd::RevaultD,
+};
+
+pub fn start(mut revaultd: RevaultD) -> Result<(), Box<dyn std::error::Error>> {
+    // First and foremost
+    setup_db(&mut revaultd).map_err(|e| {
+        log::error!("Error setting up database: '{}'", e.to_string());
+        e
+    })?;
+
+    // This aborts on error
+    let bitcoind = setup_bitcoind(&mut revaultd)?;
+
+    log::info!(
+        "revaultd started on network {}",
+        revaultd.bitcoind_config.network
+    );
+
+    // We poll bitcoind until we die
+    bitcoind_main_loop(&mut revaultd, &bitcoind).map_err(|e| {
+        log::error!("Error in bitcoind main loop: {}", e.to_string());
+        e
+    })?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,11 @@
 mod bitcoind;
 mod config;
+mod daemon;
 mod database;
 mod revaultd;
 
-use crate::{
-    bitcoind::actions::{bitcoind_main_loop, setup_bitcoind},
-    config::parse_config,
-    database::actions::setup_db,
-    revaultd::RevaultD,
-};
+use crate::daemon::start;
+use crate::{config::parse_config, revaultd::RevaultD};
 
 use std::path::PathBuf;
 use std::{env, process};
@@ -27,28 +24,6 @@ fn parse_args(args: Vec<String>) -> Option<PathBuf> {
     }
 
     Some(PathBuf::from(args[2].to_owned()))
-}
-
-fn daemon_main(mut revaultd: RevaultD) {
-    // First and foremost
-    setup_db(&mut revaultd).unwrap_or_else(|e| {
-        log::error!("Error setting up database: '{}'", e.to_string());
-        process::exit(1)
-    });
-
-    // This aborts on error
-    let bitcoind = setup_bitcoind(&mut revaultd);
-
-    log::info!(
-        "revaultd started on network {}",
-        revaultd.bitcoind_config.network
-    );
-
-    // We poll bitcoind until we die
-    bitcoind_main_loop(&mut revaultd, &bitcoind).unwrap_or_else(|e| {
-        log::error!("Error in bitcoind main loop: {}", e.to_string());
-        process::exit(1)
-    });
 }
 
 // This creates the log file automagically if it doesn't exist, and logs on stdout
@@ -110,5 +85,5 @@ fn main() {
         });
         println!("Started revaultd daemon");
     }
-    daemon_main(revaultd);
+    start(revaultd);
 }


### PR DESCRIPTION
In order to use revaultd as a library to start a revault daemon in Robalo, I need to remove process::exit from packages in order to have a clean way to control process and let the main function handle it.

I introduce in this change a new module: `daemon` which should manage the overall processes working in the daemon_loop.
The name collude with `revaultd`, thats why I suggest we rename `revaultd` to `revault` and  `Revaultd` to `Revault` because, this package and this struct are dedicated to the representation of the Revault protocole setup only. 