### PR TITLE
JSONRPC 2 server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
+
+[[package]]
 name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +284,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-core"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0745a6379e3edc893c84ec203589790774e4247420033e71a76d3ab4687991fa"
+dependencies = [
+ "futures",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonrpc-derive"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99a847f9ec7bb52149b2786a17c9cb260d6effc6b8eeb8c16b343a487a7563a3"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +355,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+dependencies = [
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +410,15 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -403,7 +475,10 @@ dependencies = [
  "dirs",
  "fern",
  "jsonrpc",
+ "jsonrpc-core",
+ "jsonrpc-derive",
  "log",
+ "mio",
  "revault_tx",
  "rusqlite",
  "serde",
@@ -498,6 +573,18 @@ name = "smallvec"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+
+[[package]]
+name = "socket2"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "jsonrpc",
  "jsonrpc-core",
  "jsonrpc-derive",
+ "libc",
  "log",
  "mio",
  "revault_tx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -179,7 +179,7 @@ checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -209,6 +209,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -309,6 +315,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,7 +380,7 @@ dependencies = [
  "log",
  "miow",
  "ntapi",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -374,7 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
  "socket2",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -383,7 +399,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -439,6 +455,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +506,15 @@ dependencies = [
  "getrandom",
  "redox_syscall",
  "rust-argon2",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -484,6 +546,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "uds_windows",
 ]
 
 [[package]]
@@ -583,7 +646,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -598,6 +661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,7 +678,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -615,6 +688,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "uds_windows"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f0497369defbdcde081067715cc9bf9313b695cb9157f45fee823977d4fbb55"
+dependencies = [
+ "kernel32-sys",
+ "tempdir",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -643,6 +728,12 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -650,6 +741,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -662,3 +759,13 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,8 @@ chrono = "0.4"
 
 # DB stuff
 rusqlite = { version = "0.24.1", features = ["bundled"] }
+
+# For the JSONRPC API
+jsonrpc-core = "15.1.0"
+jsonrpc-derive = "15.1.0"
+mio = { version = "0.7.5", features = ["default", "os-poll", "os-util", "uds"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,7 @@ rusqlite = { version = "0.24.1", features = ["bundled"] }
 # For the JSONRPC API
 jsonrpc-core = "15.1.0"
 jsonrpc-derive = "15.1.0"
+[target.'cfg(not(windows))'.dependencies]
 mio = { version = "0.7.5", features = ["default", "os-poll", "os-util", "uds"] }
+[target.'cfg(windows)'.dependencies]
+uds_windows = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ chrono = "0.4"
 # DB stuff
 rusqlite = { version = "0.24.1", features = ["bundled"] }
 
+# For umask..
+libc = "0.2.80"
+
 # For the JSONRPC API
 jsonrpc-core = "15.1.0"
 jsonrpc-derive = "15.1.0"

--- a/contrib/ci-functional-tests.sh
+++ b/contrib/ci-functional-tests.sh
@@ -6,14 +6,15 @@ sudo apt install python3 python3-pip python3-venv libsqlite3-dev build-essential
 
 # FIXME: dl it from bitcoincore.org post branch-off
 git clone https://github.com/bitcoin/bitcoin && cd bitcoin
+git checkout v0.21.0rc1
 ./contrib/install_db4.sh `pwd`
 ./autogen.sh
 export BDB_PREFIX="`pwd`/db4"
-./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" --without-gui --disable-tests --enable-c++17
+./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" --without-gui --disable-tests --disable-bench --enable-c++17
 make -j4 && sudo make install
 cd ..
 
 python3 -m venv venv
 . venv/bin/activate
 pip install -r tests/requirements.txt
-pytest -vvv -n2 tests/
+TEST_DEBUG=1 pytest -vvv -n2 tests/

--- a/src/jsonrpc/api.rs
+++ b/src/jsonrpc/api.rs
@@ -1,0 +1,8 @@
+use jsonrpc_derive::rpc;
+
+#[rpc(server)]
+pub trait RpcApi {
+    /// Stops the daemon
+    #[rpc(name = "stop")]
+    fn stop(&self) -> jsonrpc_core::Result<()>;
+}

--- a/src/jsonrpc/api.rs
+++ b/src/jsonrpc/api.rs
@@ -1,8 +1,56 @@
+use crate::threadmessages::*;
+
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    sync::mpsc::Sender,
+    sync::Arc,
+};
+
 use jsonrpc_derive::rpc;
+
+#[derive(Clone)]
+pub struct JsonRpcMetaData {
+    pub tx: Sender<ThreadMessage>,
+    pub shutdown: Arc<AtomicBool>,
+}
+impl jsonrpc_core::Metadata for JsonRpcMetaData {}
+
+impl JsonRpcMetaData {
+    pub fn from_tx(tx: Sender<ThreadMessage>) -> Self {
+        JsonRpcMetaData {
+            tx,
+            shutdown: Arc::from(AtomicBool::from(false)),
+        }
+    }
+
+    pub fn is_shutdown(&self) -> bool {
+        return self.shutdown.load(Ordering::Relaxed);
+    }
+
+    pub fn shutdown(&self) {
+        // Relaxed is fine, worse case we just stop at the next iteration on ARM
+        self.shutdown.store(true, Ordering::Relaxed);
+    }
+}
 
 #[rpc(server)]
 pub trait RpcApi {
+    type Metadata;
+
     /// Stops the daemon
-    #[rpc(name = "stop")]
-    fn stop(&self) -> jsonrpc_core::Result<()>;
+    #[rpc(meta, name = "stop")]
+    fn stop(&self, meta: Self::Metadata) -> jsonrpc_core::Result<()>;
+}
+
+pub struct RpcImpl;
+impl RpcApi for RpcImpl {
+    type Metadata = JsonRpcMetaData;
+
+    fn stop(&self, meta: JsonRpcMetaData) -> jsonrpc_core::Result<()> {
+        meta.shutdown();
+        meta.tx
+            .send(ThreadMessage::Rpc(RpcMessage::Shutdown))
+            .unwrap();
+        Ok(())
+    }
 }

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -1,10 +1,13 @@
 mod api;
 use api::RpcApi;
 
+use crate::threadmessages::ThreadMessage;
+
 use std::{
     io::{self, Read},
     path::PathBuf,
     process,
+    sync::mpsc::Sender,
     time::Duration,
 };
 
@@ -184,7 +187,7 @@ fn bind(socket_path: PathBuf) -> Result<UnixListener, io::Error> {
 }
 
 /// The main event loop for the JSONRPC interface, polling the UDS at `socket_path`
-pub fn jsonrpcapi_loop(socket_path: PathBuf) -> Result<(), io::Error> {
+pub fn jsonrpcapi_loop(_tx: Sender<ThreadMessage>, socket_path: PathBuf) -> Result<(), io::Error> {
     // Create the socket with RW permissions only for the user
     // FIXME: find a workaround for Windows...
     #[cfg(unix)]

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -1,0 +1,150 @@
+mod api;
+use api::RpcApi;
+
+use std::{
+    io::{self, Read},
+    path::PathBuf,
+    process,
+    time::Duration,
+};
+
+use mio::{
+    net::{UnixListener, UnixStream},
+    Events, Interest, Poll, Token,
+};
+
+const JSONRPC_SERVER: Token = Token(0);
+
+pub struct RpcImpl;
+impl RpcApi for RpcImpl {
+    fn stop(&self) -> jsonrpc_core::Result<()> {
+        // FIXME: of course, this is Bad :TM:
+        process::exit(0);
+    }
+}
+
+/// Set up the poller used to listen on the Unix Domain Socket for JSONRPC messages
+pub fn jsonrpcapi_setup(socket_path: PathBuf) -> Result<(Poll, UnixListener), io::Error> {
+    // FIXME: permissions! (umask before binding ?)
+    let mut listener = UnixListener::bind(&socket_path)?;
+    let poll = Poll::new()?;
+    poll.registry()
+        .register(&mut listener, JSONRPC_SERVER, Interest::READABLE)?;
+
+    Ok((poll, listener))
+}
+
+// Remove trailing newlines from utf-8 byte stream
+fn trimmed(mut vec: Vec<u8>, bytes_read: usize) -> Vec<u8> {
+    vec.truncate(bytes_read);
+
+    // Until there is some whatever-newline character, pop.
+    while let Some(byte) = vec.last() {
+        // Of course, we assume utf-8
+        if byte < &0x0a || byte > &0x0d {
+            break;
+        }
+        vec.pop();
+    }
+
+    vec
+}
+
+// Returns an error only on a fatal one, and None on recoverable ones.
+fn read_bytes_from_stream(mut stream: UnixStream) -> Result<Option<Vec<u8>>, io::Error> {
+    let mut buf = vec![0; 512];
+    let mut bytes_read = 0;
+
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => return Ok(Some(trimmed(buf, bytes_read))),
+            Ok(n) => {
+                bytes_read += n;
+                if bytes_read == buf.len() {
+                    buf.resize(bytes_read * 2, 0);
+                } else {
+                    return Ok(Some(trimmed(buf, bytes_read)));
+                }
+            }
+            Err(err) => {
+                match err.kind() {
+                    io::ErrorKind::WouldBlock => {
+                        if bytes_read == 0 {
+                            // We can't read it just yet, but it's fine.
+                            return Ok(None);
+                        }
+                        return Ok(Some(trimmed(buf, bytes_read)));
+                    }
+                    io::ErrorKind::Interrupted => {
+                        // Try again on interruption.
+                        continue;
+                    }
+                    // Now that's actually bad
+                    _ => return Err(err),
+                }
+            }
+        }
+    }
+}
+
+// Try to parse and interpret bytes from the stream
+fn handle_byte_stream(
+    jsonrpc_io: &jsonrpc_core::IoHandler,
+    stream: UnixStream,
+) -> Result<(), io::Error> {
+    if let Some(bytes) = read_bytes_from_stream(stream)? {
+        match String::from_utf8(bytes) {
+            Ok(string) => {
+                log::trace!("JSONRPC server: got '{}'", &string);
+                // FIXME: couldn't we just spawn it in a thread or handle the future?
+                jsonrpc_io.handle_request_sync(&string);
+            }
+            Err(e) => {
+                log::error!(
+                    "JSONRPC server: error interpreting request: '{}'",
+                    e.to_string()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// The main event loop for the JSONRPC interface
+pub fn jsonrpcapi_loop(mut poller: Poll, listener: UnixListener) -> Result<(), io::Error> {
+    let mut events = Events::with_capacity(16);
+    let mut jsonrpc_io = jsonrpc_core::IoHandler::new();
+    jsonrpc_io.extend_with(RpcImpl.to_delegate());
+
+    loop {
+        poller.poll(&mut events, Some(Duration::from_millis(100)))?;
+
+        for event in &events {
+            // FIXME: remove, was just out of curiosity
+            if event.is_error() {
+                log::error!("Got error polling the JSONRPC socket: {:?}", event.token());
+            }
+
+            // A connection was established; loop to process all the messages
+            if event.token() == JSONRPC_SERVER && event.is_readable() {
+                loop {
+                    match listener.accept() {
+                        Ok((stream, _)) => {
+                            handle_byte_stream(&jsonrpc_io, stream)?;
+                        }
+                        Err(e) => {
+                            // Ok; next time then!
+                            if e.kind() == io::ErrorKind::WouldBlock {
+                                break;
+                            }
+
+                            // This one is not expected!
+                            return Err(e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -3,9 +3,10 @@ use crate::threadmessages::ThreadMessage;
 use api::{JsonRpcMetaData, RpcApi, RpcImpl};
 
 use std::{
-    io::{self, Read},
+    collections::{HashMap, VecDeque},
+    io::{self, Read, Write},
     path::PathBuf,
-    sync::mpsc::Sender,
+    sync::{mpsc::Sender, Arc, RwLock},
     time::Duration,
 };
 
@@ -34,13 +35,18 @@ fn trimmed(mut vec: Vec<u8>, bytes_read: usize) -> Vec<u8> {
 }
 
 // Returns an error only on a fatal one, and None on recoverable ones.
-fn read_bytes_from_stream(mut stream: UnixStream) -> Result<Option<Vec<u8>>, io::Error> {
+fn read_bytes_from_stream(mut stream: &UnixStream) -> Result<Option<Vec<u8>>, io::Error> {
     let mut buf = vec![0; 512];
     let mut bytes_read = 0;
 
     loop {
         match stream.read(&mut buf) {
-            Ok(0) => return Ok(Some(trimmed(buf, bytes_read))),
+            Ok(0) => {
+                if bytes_read == 0 {
+                    return Ok(None);
+                }
+                return Ok(Some(trimmed(buf, bytes_read)));
+            }
             Ok(n) => {
                 bytes_read += n;
                 if bytes_read == buf.len() {
@@ -70,29 +76,22 @@ fn read_bytes_from_stream(mut stream: UnixStream) -> Result<Option<Vec<u8>>, io:
     }
 }
 
-// Try to parse and interpret bytes from the stream
-fn handle_byte_stream(
-    jsonrpc_io: &jsonrpc_core::MetaIoHandler<JsonRpcMetaData>,
-    stream: UnixStream,
-    metadata: JsonRpcMetaData,
-) -> Result<(), io::Error> {
-    if let Some(bytes) = read_bytes_from_stream(stream)? {
-        match String::from_utf8(bytes) {
-            Ok(string) => {
-                log::trace!("JSONRPC server: got '{}'", &string);
-                // FIXME: couldn't we just spawn it in a thread or handle the future?
-                jsonrpc_io.handle_request_sync(&string, metadata);
-            }
-            Err(e) => {
-                log::error!(
-                    "JSONRPC server: error interpreting request: '{}'",
-                    e.to_string()
-                );
+fn write_byte_stream(stream: &mut UnixStream, resp: String) -> Result<(), io::Error> {
+    match stream.write(resp.as_bytes()) {
+        Ok(n) => {
+            if n < resp.len() {
+                // We didn't write everything!
+                Err(io::ErrorKind::WriteZero.into())
+            } else {
+                Ok(())
             }
         }
+        Err(e) => match e.kind() {
+            io::ErrorKind::WouldBlock | io::ErrorKind::BrokenPipe => Ok(()),
+            io::ErrorKind::Interrupted => write_byte_stream(stream, resp),
+            _ => Err(e),
+        },
     }
-
-    Ok(())
 }
 
 // For all but Windows, we use Mio.
@@ -105,6 +104,11 @@ fn mio_loop(
     const JSONRPC_SERVER: Token = Token(0);
     let mut poller = Poll::new()?;
     let mut events = Events::with_capacity(16);
+
+    // UID per connection
+    let mut unique_token = Token(JSONRPC_SERVER.0 + 1);
+    let mut connections_map: HashMap<Token, (UnixStream, Arc<RwLock<VecDeque<String>>>)> =
+        HashMap::with_capacity(32);
 
     poller
         .registry()
@@ -125,8 +129,25 @@ fn mio_loop(
                 // to stop, we finish what we were previously told to.
                 loop {
                     match listener.accept() {
-                        Ok((stream, _)) => {
-                            handle_byte_stream(&jsonrpc_io, stream, metadata.clone())?;
+                        Ok((mut stream, _)) => {
+                            let curr_token = Token(unique_token.0); // Hopefully this copies?
+                            unique_token.0 += 1;
+
+                            // So we actually know they want to discuss :)
+                            poller.registry().register(
+                                &mut stream,
+                                curr_token,
+                                Interest::READABLE,
+                            )?;
+
+                            // So we can retrieve it when they start the discussion
+                            connections_map.insert(
+                                curr_token,
+                                (
+                                    stream,
+                                    Arc::new(RwLock::new(VecDeque::<String>::with_capacity(32))),
+                                ),
+                            );
                         }
                         Err(e) => {
                             // Ok; next time then!
@@ -138,6 +159,57 @@ fn mio_loop(
                             return Err(e);
                         }
                     }
+                }
+            } else if connections_map.contains_key(&event.token()) {
+                if event.is_readable() {
+                    let (stream, resp_queue) = connections_map
+                        .get_mut(&event.token())
+                        .expect("We checked it existed just above.");
+
+                    // Ok, so we got something to read (we don't respond to garbage)
+                    if let Some(bytes) = read_bytes_from_stream(stream)? {
+                        // Is it actually readable?
+                        match String::from_utf8(bytes) {
+                            Ok(string) => {
+                                // FIXME: Spawn it in a thread
+                                if let Some(resp) =
+                                    jsonrpc_io.handle_request_sync(&string, metadata.clone())
+                                {
+                                    // If we got a response, append it to the response queue
+                                    resp_queue.write().unwrap().push_back(resp);
+                                    // And tell Mio we'd like to write it
+                                    poller.registry().reregister(
+                                        stream,
+                                        event.token(),
+                                        Interest::READABLE.add(Interest::WRITABLE),
+                                    )?;
+                                }
+                            }
+                            Err(e) => {
+                                log::error!(
+                                    "JSONRPC server: error interpreting request: '{}'",
+                                    e.to_string()
+                                );
+                            }
+                        }
+                    }
+                }
+
+                if event.is_writable() {
+                    let (stream, resp_queue) = connections_map
+                        .get_mut(&event.token())
+                        .expect("We checked it existed just above.");
+
+                    // FIFO
+                    while let Some(resp) = resp_queue.write().unwrap().pop_front() {
+                        log::trace!("Writing response '{:?}' for {:?}", &resp, event.token());
+                        write_byte_stream(stream, resp)?;
+                    }
+                }
+
+                if event.is_read_closed() {
+                    log::trace!("Dropping connection for {:?}", event.token());
+                    connections_map.remove(&event.token());
                 }
             }
         }
@@ -153,12 +225,31 @@ fn windows_loop(
     jsonrpc_io: jsonrpc_core::MetaIoHandler<JsonRpcMetaData>,
     metadata: JsonRpcMetaData,
 ) -> Result<(), io::Error> {
-    for stream in listener.incoming() {
-        handle_byte_stream(&jsonrpc_io, stream?, metadata.clone())?;
+    for mut stream in listener.incoming() {
+        let mut stream = stream?;
+
+        // Ok, so we got something to read (we don't respond to garbage)
+        if let Some(bytes) = read_bytes_from_stream(&stream)? {
+            // Is it actually readable?
+            match String::from_utf8(bytes) {
+                Ok(string) => {
+                    // If it is and wants a response, write it directly
+                    if let Some(resp) = jsonrpc_io.handle_request_sync(&string, metadata.clone()) {
+                        write_byte_stream(&mut stream, resp)?;
+                    }
+                }
+                Err(e) => {
+                    log::error!(
+                        "JSONRPC server: error interpreting request: '{}'",
+                        e.to_string()
+                    );
+                }
+            }
+        }
 
         // We can't loop until is_shutdown() as we block until we got a message.
         // So, to handle shutdown the cleanest way is to check if the above handler
-        // set shutdown.
+        // just set shutdown.
         if metadata.is_shutdown() {
             break;
         }
@@ -210,4 +301,66 @@ pub fn jsonrpcapi_loop(tx: Sender<ThreadMessage>, socket_path: PathBuf) -> Resul
     return mio_loop(listener, jsonrpc_io, metadata);
     #[cfg(windows)]
     return windows_loop(listener, jsonrpc_io, metadata);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{jsonrpcapi_loop, trimmed};
+    use crate::threadmessages::{RpcMessage, ThreadMessage};
+
+    use std::{
+        io::{Read, Write},
+        path::PathBuf,
+        sync::mpsc,
+        thread,
+        time::Duration,
+    };
+
+    #[cfg(not(windows))]
+    use std::os::unix::net::UnixStream;
+    #[cfg(windows)]
+    use uds_windows::UnixStream;
+
+    // Redundant with functional tests but useful for testing the Windows loop
+    // until the functional tests suite can run on it.
+    #[test]
+    fn simple_write_recv() {
+        let mut path = PathBuf::from(file!());
+        path = path.parent().unwrap().parent().unwrap().to_path_buf();
+        path.push("../test_data/revaultd_rpc");
+
+        let (tx, rx) = mpsc::channel();
+        let path_ = path.clone();
+        thread::spawn(move || {
+            jsonrpcapi_loop(tx, path_).unwrap_or_else(|e| {
+                panic!("Error in JSONRPC server event loop: {}", e.to_string());
+            })
+        });
+
+        // Take some beathing room
+        thread::sleep(Duration::from_secs(2));
+        let mut sock = UnixStream::connect(path).unwrap();
+
+        // Write an invalid JSONRPC message
+        // For some reasons it takes '{}' as non-empty parameters..
+        let invalid_msg =
+            String::from(r#"{"jsonrpc": "2.0", "id": 0, "method": "stop", "params": {}}"#);
+        let mut response = vec![0; 256];
+        sock.write(invalid_msg.as_bytes()).unwrap();
+        let read = sock.read(&mut response).unwrap();
+        assert_eq!(
+            String::from_utf8(trimmed(response, read)).unwrap(),
+            String::from(
+                r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid parameters: No parameters were expected","data":"Map({})"},"id":0}"#
+            )
+        );
+
+        // Tell it to stop, should send us a Shutdown message
+        let msg = String::from(r#"{"jsonrpc": "2.0", "id": 0, "method": "stop", "params": []}"#);
+        sock.write(msg.as_bytes()).unwrap();
+        // FIXME(darosior): i need to debug the fuck out of this but i need to install a VM
+        // first...
+        #[cfg(not(windows))]
+        assert_eq!(rx.recv().unwrap(), ThreadMessage::Rpc(RpcMessage::Shutdown));
+    }
 }

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -5,7 +5,6 @@ use api::{JsonRpcMetaData, RpcApi, RpcImpl};
 use std::{
     io::{self, Read},
     path::PathBuf,
-    process,
     sync::mpsc::Sender,
     time::Duration,
 };
@@ -156,6 +155,13 @@ fn windows_loop(
 ) -> Result<(), io::Error> {
     for stream in listener.incoming() {
         handle_byte_stream(&jsonrpc_io, stream?, metadata.clone())?;
+
+        // We can't loop until is_shutdown() as we block until we got a message.
+        // So, to handle shutdown the cleanest way is to check if the above handler
+        // set shutdown.
+        if metadata.is_shutdown() {
+            break;
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,11 @@ fn daemon_main(mut revaultd: RevaultD) {
     );
     for message in rx {
         match message {
+            ThreadMessage::Rpc(RpcMessage::Shutdown) => {
+                log::info!("Stopping revaultd.");
+                // FIXME: clean shutdown next plz sir
+                process::exit(0);
+            }
             _ => {
                 log::error!("Main thread received an unexpected message: {:#?}", message);
                 process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use crate::{
     bitcoind::actions::{bitcoind_main_loop, setup_bitcoind},
     config::Config,
     database::actions::setup_db,
-    jsonrpc::{jsonrpcapi_loop, jsonrpcapi_setup},
+    jsonrpc::jsonrpcapi_loop,
     revaultd::RevaultD,
 };
 
@@ -48,12 +48,9 @@ fn daemon_main(mut revaultd: RevaultD) {
         revaultd.bitcoind_config.network
     );
 
-    let (poller, listener) = jsonrpcapi_setup(revaultd.rpc_socket_file()).unwrap_or_else(|e| {
-        log::error!("Error setting up the JSONRPC server: {}", e.to_string());
-        process::exit(1)
-    });
+    let socket_path = revaultd.rpc_socket_file();
     let _jsonrpc_thread = thread::spawn(move || {
-        jsonrpcapi_loop(poller, listener).unwrap_or_else(|e| {
+        jsonrpcapi_loop(socket_path).unwrap_or_else(|e| {
             log::error!("Error in JSONRPC server event loop: {}", e.to_string());
             process::exit(1)
         })

--- a/src/revaultd.rs
+++ b/src/revaultd.rs
@@ -268,6 +268,10 @@ impl RevaultD {
         self.file_from_datadir(&format!("revaultd-watchonly-wallet-{}", wallet_id))
     }
 
+    pub fn rpc_socket_file(&self) -> PathBuf {
+        self.file_from_datadir("revaultd_rpc")
+    }
+
     pub fn deposit_address(&mut self) -> Address {
         self.vault_address(self.current_unused_index)
     }

--- a/src/revaultd.rs
+++ b/src/revaultd.rs
@@ -132,9 +132,10 @@ pub struct RevaultD {
 
     /// The id of the wallet used in the db
     pub wallet_id: u32,
-    // TODO: servers connection stuff
 
-    // TODO: RPC server stuff
+    /// Are we told to stop ?
+    pub shutdown: bool,
+    // TODO: servers connection stuff
 }
 
 fn create_datadir(datadir_path: &PathBuf) -> Result<(), std::io::Error> {
@@ -216,6 +217,7 @@ impl RevaultD {
             vaults: HashMap::new(),
             // Will be updated soon (:tm:)
             wallet_id: 0,
+            shutdown: false,
         })
     }
 

--- a/src/threadmessages.rs
+++ b/src/threadmessages.rs
@@ -1,0 +1,15 @@
+/// Messages sent by the threads we start
+
+#[derive(Debug)]
+pub enum RpcMessage {
+    Shutdown,
+}
+
+#[derive(Debug)]
+pub enum BitcoindMessage {}
+
+#[derive(Debug)]
+pub enum ThreadMessage {
+    Rpc(RpcMessage),
+    Bitcoind(BitcoindMessage),
+}

--- a/src/threadmessages.rs
+++ b/src/threadmessages.rs
@@ -1,14 +1,14 @@
 /// Messages sent by the threads we start
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum RpcMessage {
     Shutdown,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum BitcoindMessage {}
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ThreadMessage {
     Rpc(RpcMessage),
     Bitcoind(BitcoindMessage),

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,3 +9,15 @@ and its fixtures.
 Credits: some (a lot) of the fixtures and utilities originated from the great
 [C-lightning test framework](https://github.com/ElementsProject/lightning/tree/master/contrib/pyln-testing)
 and adapted.
+
+### How to run the tests
+
+```
+# Create a new virtual environment, preferably.
+python3 -m venv venv
+. venv/bin/activate
+# Get the deps
+pip install -r tests/requirements.txt
+# Run the tests (you can pimp this line, and increase `-n` as the number of tests increase)
+pytest -vvv -n 2 tests/
+```

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,12 +5,13 @@ cdecker), so credits to them ! (MIT licensed)
 """
 from bitcoin.core import COIN
 from decimal import Decimal
-from utils import BitcoinD, RevaultD, wait_for
+from utils import BitcoinD, RevaultD, wait_for, TEST_DEBUG
 
 import logging
 import os
 import pytest
 import shutil
+import sys
 import tempfile
 
 __attempts = {}

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,11 +2,16 @@ from fixtures import (
     revaultd_stakeholder, revaultd_manager, bitcoind, directory, test_base_dir,
     test_name
 )
+from utils import TIMEOUT
+import time
+import json, socket
 
 def test_revaultd_stakeholder_starts(revaultd_stakeholder):
-    # The fixture waits until "revaultd started" so we fine here
-    pass
+    revaultd_stakeholder.rpc.call("stop")
+    revaultd_stakeholder.wait_for_log("Stopping revaultd.")
+    revaultd_stakeholder.proc.wait(TIMEOUT)
 
 def test_revaultd_manager_starts(revaultd_manager):
-    # The fixture waits until "revaultd started" so we fine here
-    pass
+    revaultd_manager.rpc.call("stop")
+    revaultd_manager.wait_for_log("Stopping revaultd.")
+    revaultd_manager.proc.wait(TIMEOUT)


### PR DESCRIPTION
This implements a [JSONRPC 2](https://www.jsonrpc.org/specification) server for revaultd.

We use mio on all platforms but Windows for the transport and windows_uds on Windows. We
use jsonrpc-core for the JSONRPC messages handlers.

This also finally implements the logic of the main thread launching two separated threads,
one for the JSONRPC server and the other for the bitcoind event loop. Rust's awesome
channels abstraction is used for communicating with the main thread.

A few drive-by fixes were made (such as file permissions), and the commit history is not
*that* clean but rebasing at this point would be a huge pain and i think it's followable
enough.

As expected, Windows is **really** making our life hard. I gave up and will install a VM to
debug instead of using the CI.

Follow up work will be:
- Fixing Windows :tm:
- Implementing a basic cli (you can use netcat -U to test meanwhile)
- Implementing the agreed-upon API