### PR TITLE
Implement `getrevocationtxs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,8 +521,9 @@ dependencies = [
 [[package]]
 name = "revault_tx"
 version = "0.0.1"
-source = "git+https://github.com/darosior/revault?branch=update_miniscript#194a765b43e05965e3b815bbe98a94bf3a3d40c5"
+source = "git+https://github.com/darosior/revault?branch=refinement#5c17f61b51e64f3cfb32172b25d811a147fa22f1"
 dependencies = [
+ "base64 0.13.0",
  "bitcoinconsensus",
  "miniscript",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "revault-cli"
 path = "src/cli/main.rs"
 
 [dependencies]
-revault_tx = { git = "https://github.com/darosior/revault", branch = "update_miniscript" }
+revault_tx = { git = "https://github.com/darosior/revault", branch = "refinement" }
 
 # Don't reinvent the wheel
 dirs = "3.0.1"

--- a/contrib/ci-functional-tests.sh
+++ b/contrib/ci-functional-tests.sh
@@ -15,4 +15,5 @@ sudo mv $DIR_NAME/bin/bitcoind /usr/local/bin/
 python3 -m venv venv
 . venv/bin/activate
 pip install -r tests/requirements.txt
-TEST_DEBUG=1 pytest -vvv -n2 tests/
+# GA is f*ing slow. But free!
+TIMEOUT=120 TEST_DEBUG=1 pytest -vvv tests/

--- a/contrib/ci-functional-tests.sh
+++ b/contrib/ci-functional-tests.sh
@@ -15,4 +15,4 @@ sudo mv $DIR_NAME/bin/bitcoind /usr/local/bin/
 python3 -m venv venv
 . venv/bin/activate
 pip install -r tests/requirements.txt
-TEST_DEBUG=1 pytest -vvv -n4 tests/
+TEST_DEBUG=1 pytest -vvv -n2 tests/

--- a/doc/API.md
+++ b/doc/API.md
@@ -130,7 +130,8 @@ vault with the given deposit `txid`.
 ### `getrevocationtxs`
 
 The `getrevocationtxs` RPC Command builds and returns the revocation transactions
-corresponding to a given vault.
+corresponding to a given vault. The call will fail if the `outpoint` does not refer to a
+known and confirmed ([`funded`](#vault-statuses)) vault.
 
 #### Request
 
@@ -235,7 +236,7 @@ amount of the output.
   | +------sig---------> |                          |
   |                      |                          |
   | <+sign unvault_emer+ |                          |
-  | +------------------> |                          |
+  | +------sig---------> |                          |
   |                      | +---revocationtxs------> |
   |                      |                          |
   +                      | +--+listvaults secure+-> |  // check if the watchtowers has the

--- a/doc/API.md
+++ b/doc/API.md
@@ -92,14 +92,14 @@ Note that the `scriptPubKey` is implicitly known as we have the vault output Min
 ### `listvaults`
 
 The `listvaults` RPC command displays a list of vaults optionally filtered by
-either `status` or deposit `txids`.
+either `status` or deposit `outpoints`.
 
 #### Request
 
-| Parameter | Type         | Description                                                                                     |
-| --------- | ------------ | ----------------------------------------------------------------------------------------------- |
-| `status`  | string array | Vault status -- optional, see [vault statuses](#vault-statuses) for possible values             |
-| `txids`   | string array | Vault IDs -- optional, filter the list with the given vault IDs                                 |
+| Parameter   | Type         | Description                                                                                     |
+| ----------- | ------------ | ----------------------------------------------------------------------------------------------- |
+| `outpoints` | string array | Vault IDs -- optional, filter the list with the given vault Outpoints                           |
+| `status`    | string array | Vault status -- optional, see [vault statuses](#vault-statuses) for possible values             |
 
 #### Response
 
@@ -110,13 +110,13 @@ either `status` or deposit `txids`.
 ### `getonchaintxs`
 
 The `getonchaintxs` RPC Command retrieves the on chain transactions of a
-vault with the given deposit `txid`.
+vault with the given deposit `outpoint`.
 
 #### Request
 
 | Parameter        | Type    | Description                                     |
 | ---------------- | ------- | ----------------------------------------------- |
-| `txid`           | string  | Deposit txid of the vault                       |
+| `outpoint`       | string  | Deposit outpoint of the vault                   |
 
 #### Response
 
@@ -135,9 +135,9 @@ known and confirmed ([`funded`](#vault-statuses)) vault.
 
 #### Request
 
-| Parameter        | Type    | Description                                     |
-| ---------------- | ------- | ----------------------------------------------- |
-| `txid`           | string  | Deposit txid of the vault                       |
+| Parameter            | Type    | Description                                     |
+| -------------------- | ------- | ----------------------------------------------- |
+| `outpoint`           | string  | Deposit outpoint of the vault                   |
 
 #### Response
 
@@ -166,9 +166,9 @@ vault.
 
 #### Request
 
-| Parameter        | Type    | Description                           |
-| ---------------- | ------- | ------------------------------------- |
-| `txid`           | string  | Deposit txid of the vault to activate |
+| Parameter        | Type    | Description                               |
+| ---------------- | ------- | ----------------------------------------- |
+| `outpoint`       | string  | Deposit outpoint of the vault to activate |
 
 #### Response
 
@@ -191,10 +191,10 @@ set of vaults to spend.
 
 #### Request
 
-| Parameter | Type                 | Description                                                       |
-| --------- | -------------------- | ----------------------------------------------------------------- |
-| `txid`    | string array         | Vault deposit txids -- vaults must be [`active`](#vault-statuses) |
-| `output`  | map of string to int | Map of Bitcoin addresses to amount                                |
+| Parameter   | Type                 | Description                                                           |
+| ----------- | -------------------- | --------------------------------------------------------------------- |
+| `outpoints` | string array         | Vault deposit outpoints -- vaults must be [`active`](#vault-statuses) |
+| `output`    | map of string to int | Map of Bitcoin addresses to amount                                    |
 
 Fee is deducted from the total amount of the vaults spent minus the total
 amount of the output.

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -43,14 +43,17 @@ fn parse_args(mut args: Vec<String>) -> (Option<PathBuf>, String, Vec<String>) {
     }
 }
 
-fn rpc_request(method: String, params: Vec<String>) -> serde_json::Result<Json> {
+// Defaults to String Value when parsing fails, as it fails to parse outpoints otherwise...
+fn from_str_hack(token: String) -> Json {
+    match serde_json::from_str(&token) {
+        Ok(json) => json,
+        Err(_) => Json::String(token),
+    }
+}
+
+fn rpc_request(method: String, params: Vec<String>) -> Json {
     let method = Json::String(method);
-    let params = Json::Array(
-        params
-            .into_iter()
-            .map(|string| serde_json::from_str(&string))
-            .collect::<serde_json::Result<Vec<Json>>>()?,
-    );
+    let params = Json::Array(params.into_iter().map(from_str_hack).collect::<Vec<Json>>());
     let mut object = serde_json::Map::<String, Json>::new();
     object.insert("jsonrpc".to_string(), Json::String("2.0".to_string()));
     object.insert(
@@ -60,7 +63,7 @@ fn rpc_request(method: String, params: Vec<String>) -> serde_json::Result<Json> 
     object.insert("method".to_string(), method);
     object.insert("params".to_string(), params);
 
-    Ok(Json::Object(object))
+    Json::Object(object)
 }
 
 fn socket_file(conf_file: Option<PathBuf>) -> PathBuf {
@@ -103,10 +106,7 @@ fn trimmed(mut vec: Vec<u8>, bytes_read: usize) -> Vec<u8> {
 fn main() {
     let args = env::args().collect();
     let (conf_file, method, params) = parse_args(args);
-    let request = rpc_request(method, params).unwrap_or_else(|e| {
-        eprintln!("Invalid parameters: '{}'", e);
-        process::exit(1);
-    });
+    let request = rpc_request(method, params);
     let socket_file = socket_file(conf_file);
     let mut raw_response = vec![0; 256];
     let mut response: Json;

--- a/src/daemon/database/actions.rs
+++ b/src/daemon/database/actions.rs
@@ -144,8 +144,8 @@ fn state_from_db(revaultd: &mut RevaultD) -> Result<(), DatabaseError> {
 
     revaultd.tip = Some(db_tip(&db_path)?);
 
-    //FIXME: Find a way to check if the policies described in the config files are equivalent
-    // to the miniscript in the db.
+    //FIXME: Use the Abstract Miniscript policy to check the policies described in the
+    // config files are equivalent to the miniscript in the db.
     revaultd.vault_descriptor =
         VaultDescriptor(Descriptor::from_str(&wallet.vault_descriptor).map_err(|e| {
             DatabaseError(format!(

--- a/src/daemon/database/mod.rs
+++ b/src/daemon/database/mod.rs
@@ -1,4 +1,6 @@
 pub mod actions;
+// We don't use all the interfaces just yet
+#[allow(dead_code)]
 pub mod interface;
 mod schema;
 

--- a/src/daemon/jsonrpc/api.rs
+++ b/src/daemon/jsonrpc/api.rs
@@ -63,6 +63,7 @@ pub trait RpcApi {
         &self,
         meta: Self::Metadata,
         status: Option<Vec<String>>,
+        // FIXME: should be outpoints!!
         txids: Option<Vec<String>>,
     ) -> jsonrpc_core::Result<serde_json::Value>;
 
@@ -240,9 +241,9 @@ impl RpcApi for RpcImpl {
             })?;
 
         Ok(json!({
-            "cancel_tx": cancel_tx.as_psbt_string().unwrap(),
-            "emergency_tx": emer_tx.as_psbt_string().unwrap(),
-            "emergency_unvault_tx": unemer_tx.as_psbt_string().unwrap(),
+            "cancel_tx": cancel_tx.as_psbt_string().expect("We just derived it"),
+            "emergency_tx": emer_tx.as_psbt_string().expect("We just derived it"),
+            "emergency_unvault_tx": unemer_tx.as_psbt_string().expect("We just derived it"),
         }))
     }
 }

--- a/src/daemon/jsonrpc/mod.rs
+++ b/src/daemon/jsonrpc/mod.rs
@@ -80,7 +80,7 @@ fn read_bytes_from_stream(mut stream: &UnixStream) -> Result<Option<Vec<u8>>, io
 }
 
 // Returns Ok(true) on written data and Ok(false) on non-fatal error but non-written data
-fn write_byte_stream(stream: &mut UnixStream, resp: &String) -> Result<bool, io::Error> {
+fn write_byte_stream(stream: &mut UnixStream, resp: &str) -> Result<bool, io::Error> {
     match stream.write(resp.as_bytes()) {
         Ok(n) => {
             if n < resp.len() {

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -319,9 +319,11 @@ fn main() {
     });
 
     if revaultd.daemon {
-        let mut daemon = Daemonize::default();
-        // TODO: Make this configurable for inits
-        daemon.pid_file = Some(revaultd.pid_file());
+        let daemon = Daemonize {
+            // TODO: Make this configurable for inits
+            pid_file: Some(revaultd.pid_file()),
+            ..Daemonize::default()
+        };
         daemon.doit().unwrap_or_else(|e| {
             eprintln!("Error daemonizing: {}", e);
             process::exit(1);

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -144,7 +144,7 @@ fn daemon_main(mut revaultd: RevaultD) {
                         process::exit(1);
                     });
             }
-            RpcMessageIn::ListVaults((statuses, txids), response_tx) => {
+            RpcMessageIn::ListVaults((statuses, outpoints), response_tx) => {
                 log::trace!("Got listvaults from RPC thread");
 
                 let mut resp = Vec::<(u64, String, String, u32)>::new();
@@ -155,8 +155,8 @@ fn daemon_main(mut revaultd: RevaultD) {
                         }
                     }
 
-                    if let Some(ref txids) = &txids {
-                        if !txids.contains(&outpoint.txid) {
+                    if let Some(ref outpoints) = &outpoints {
+                        if !outpoints.contains(&outpoint) {
                             continue;
                         }
                     }

--- a/src/daemon/revaultd.rs
+++ b/src/daemon/revaultd.rs
@@ -301,7 +301,7 @@ impl RevaultD {
 
     /// The context required for deriving keys. We don't use it, as it's redundant with the
     /// descriptor derivation, therefore the ChildNumber is always 0.
-    pub fn xpub_ctx<'a>(&'a self) -> DescriptorPublicKeyCtx<'a, secp256k1::VerifyOnly> {
+    pub fn xpub_ctx(&self) -> DescriptorPublicKeyCtx<'_, secp256k1::VerifyOnly> {
         DescriptorPublicKeyCtx::new(&self.secp_ctx, ChildNumber::from(0))
     }
 

--- a/src/daemon/revaultd.rs
+++ b/src/daemon/revaultd.rs
@@ -6,8 +6,8 @@ use revault_tx::{
     bitcoin::{secp256k1, util::bip32::ChildNumber, Address, BlockHash, OutPoint, Script, TxOut},
     miniscript::descriptor::{DescriptorPublicKey, DescriptorPublicKeyCtx},
     scripts::{
-        cpfp_descriptor, unvault_descriptor, vault_descriptor, CpfpDescriptor, UnvaultDescriptor,
-        VaultDescriptor,
+        cpfp_descriptor, unvault_descriptor, vault_descriptor, CpfpDescriptor, EmergencyAddress,
+        UnvaultDescriptor, VaultDescriptor,
     },
     transactions::{
         CancelTransaction, EmergencyTransaction, UnvaultEmergencyTransaction, UnvaultTransaction,
@@ -167,12 +167,17 @@ pub struct RevaultD {
     pub unvault_descriptor: UnvaultDescriptor<DescriptorPublicKey>,
     /// The miniscript descriptor of CPFP output scripts (in unvault and spend transaction)
     pub cpfp_descriptor: CpfpDescriptor<DescriptorPublicKey>,
+    pub emergency_address: EmergencyAddress,
     /// We don't make an enormous deal of address reuse (we cancel to the same keys),
     /// however we at least try to generate new addresses once they're used.
     // FIXME: think more about desync reconciliation..
     pub current_unused_index: ChildNumber,
     /// The secp context required by the xpub one.. We'll eventually use it to verify keys.
     pub secp_ctx: secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    /// The locktime to use on all created transaction. Always 0 for now.
+    pub lock_time: u32,
+    /// The CSV in the unvault_descriptor. Unfortunately segregated from the descriptor..
+    pub unvault_csv: u32,
 
     // UTXOs stuff
     /// A cache of known vaults by txid
@@ -269,6 +274,9 @@ impl RevaultD {
             secp_ctx,
             data_dir,
             daemon,
+            emergency_address: config.emergency_address.0,
+            lock_time: 0,
+            unvault_csv: config.unvault_csv,
             bitcoind_config: config.bitcoind_config,
             tip: None,
             ourselves: config.ourselves,

--- a/src/daemon/threadmessages.rs
+++ b/src/daemon/threadmessages.rs
@@ -1,5 +1,8 @@
 use crate::revaultd::VaultStatus;
-use revault_tx::bitcoin::{Address, Txid};
+use revault_tx::{
+    bitcoin::{Address, OutPoint, Txid},
+    transactions::{CancelTransaction, EmergencyTransaction, UnvaultEmergencyTransaction},
+};
 
 use std::sync::mpsc::SyncSender;
 
@@ -15,6 +18,17 @@ pub enum RpcMessageIn {
         SyncSender<Vec<(u64, String, String, u32)>>,
     ),
     DepositAddr(SyncSender<Address>),
+    GetRevocationTxs(
+        OutPoint,
+        // None if the deposit does not exist
+        SyncSender<
+            Option<(
+                CancelTransaction,
+                EmergencyTransaction,
+                UnvaultEmergencyTransaction,
+            )>,
+        >,
+    ),
 }
 
 /// Outgoing to the bitcoind poller thread

--- a/src/daemon/threadmessages.rs
+++ b/src/daemon/threadmessages.rs
@@ -1,6 +1,6 @@
 use crate::revaultd::VaultStatus;
 use revault_tx::{
-    bitcoin::{Address, OutPoint, Txid},
+    bitcoin::{Address, OutPoint},
     transactions::{CancelTransaction, EmergencyTransaction, UnvaultEmergencyTransaction},
 };
 
@@ -13,7 +13,7 @@ pub enum RpcMessageIn {
     // Network, blockheight, sync progress
     GetInfo(SyncSender<(String, u32, f64)>),
     ListVaults(
-        (Option<Vec<VaultStatus>>, Option<Vec<Txid>>),
+        (Option<Vec<VaultStatus>>, Option<Vec<OutPoint>>),
         // amount, status, txid, vout
         SyncSender<Vec<(u64, String, String, u32)>>,
     ),

--- a/test_data/datadir/config.toml
+++ b/test_data/datadir/config.toml
@@ -1,4 +1,5 @@
 unvault_csv = 42
+emergency_address = "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej"
 
 [bitcoind_config]
 network = "bitcoin"

--- a/test_data/valid_config.toml
+++ b/test_data/valid_config.toml
@@ -1,7 +1,10 @@
 unvault_csv = 18
+emergency_address = "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej"
 
 # We can set random values which'll get ignored
 wizard = "sardine"
+
+# The "daemon" entry is optional
 
 [bitcoind_config]
 network = "bitcoin"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -111,8 +111,8 @@ def revaultd_manager(bitcoind, test_base_dir):
 
 
 @pytest.fixture
-def revaultd_factory(directory, bitcoind):
-    factory = RevaultDFactory(directory, bitcoind)
+def revaultd_factory(test_base_dir, bitcoind):
+    factory = RevaultDFactory(test_base_dir, bitcoind)
 
     yield factory
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -152,14 +152,14 @@ class UnixDomainSocketRpc(object):
         s = json.dumps(obj, ensure_ascii=False)
         sock.sock.sendall(s.encode())
 
-    def _readobj(self, sock, buff=b''):
-        """Read a JSON object, starting with buff; returns object and any buffer left over."""
+    def _readobj(self, sock):
+        """Read a JSON object"""
+        buff = b""
         while True:
-            [sock], _, _ = select.select([sock.sock], [], [], TIMEOUT)
             n_to_read = max(2048, len(buff))
-            b = sock.recv(n_to_read)
-            buff += b
-            if len(b) != n_to_read:
+            chunk = sock.recv(n_to_read)
+            buff += chunk
+            if len(chunk) != n_to_read:
                 print("Got: {}", buff)
                 return json.loads(buff)
 
@@ -177,7 +177,7 @@ class UnixDomainSocketRpc(object):
             elif len(args) != 0:
                 return self.call(name, payload=args)
             else:
-                return self.call(name, payload=kwargs)
+                return self.call(name, payload=list(kwargs.values()))
         return wrapper
 
     # FIXME: support named parameters on the Rust server!

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,7 @@ import threading
 import time
 
 
-TIMEOUT = int(os.getenv("TIMEOUT", 40))
+TIMEOUT = int(os.getenv("TIMEOUT", 60))
 TEST_DEBUG = os.getenv("TEST_DEBUG", "0") == "1"
 
 
@@ -569,6 +569,9 @@ class RevaultD(TailableProc):
                                        ".cookie")
         with open(self.conf_file, 'w') as f:
             f.write(f"unvault_csv = {csv}\n")
+            # FIXME: eventually use a real one here
+            f.write("emergency_address = "
+                    "\"bcrt1qewc2348370pgw8kjz8gy09z8xyh0d9fxde6nzamd3txc9gkmjqmq8m4cdq\"\n")
             f.write(f"data_dir = '{datadir}'\n")
             f.write(f"daemon = false\n")
             f.write(f"log_level = 'trace'\n")


### PR DESCRIPTION
This implements the `getrevocationtxs` RPC, as well as a few database interface stuff and fixes the documentation (~~but not yet the implem!~~ now implemented) for the vault identifier.

~~I'll add some tests tomorrow but you can already give it a look, i tested it manually :tm:~~ Added a functional test