### PR TITLE
Listtransactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "ahash"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "arrayref"
@@ -23,12 +23,6 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -102,16 +96,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
-name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +106,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -144,12 +134,12 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -205,12 +195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,7 +212,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -252,26 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,10 +244,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 [[package]]
 name = "jsonrpc"
 version = "0.11.0"
-source = "git+https://github.com/apoelstra/rust-jsonrpc?branch=2020-09-basic-client#328a6f3ebb0ddc3b2be0322d965ef613278625a3"
+source = "git+https://github.com/stevenroose/rust-jsonrpc?branch=transport-fixes#6c2fc02600324c8d3907e5a785ebbfe7b527caea"
 dependencies = [
  "base64-compat",
- "http",
  "serde",
  "serde_derive",
  "serde_json",
@@ -332,9 +295,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -353,7 +316,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -373,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
+checksum = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
 dependencies = [
  "libc",
  "log",
@@ -386,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -523,7 +486,7 @@ name = "revault_tx"
 version = "0.0.1"
 source = "git+https://github.com/darosior/revault?branch=refinement#5c17f61b51e64f3cfb32172b25d811a147fa22f1"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bitcoinconsensus",
  "miniscript",
 ]
@@ -532,7 +495,7 @@ dependencies = [
 name = "revaultd"
 version = "0.0.2"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "chrono",
  "daemonize-simple",
  "dirs",
@@ -553,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3d4791ab5517217f51216a84a688b53c1ebf7988736469c538d02f46ddba68"
+checksum = "d5f38ee71cbab2c827ec0ac24e76f82eca723cee92c509a65f67dee393c25112"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -568,11 +531,11 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -604,18 +567,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -624,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "itoa",
  "ryu",
@@ -635,27 +598,26 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
 
 [[package]]
 name = "socket2"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
+checksum = "97e0e9fd577458a4f61fb91fcb559ea2afecc54c934119421f9f5d3d5b1a1057"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -685,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
@@ -712,9 +674,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ description = "Revault wallet daemon"
 exclude = [".github/"]
 
 
-
 [lib]
 name = "common"
 path = "src/common/lib.rs"
@@ -23,6 +22,7 @@ path = "src/daemon/main.rs"
 name = "revault-cli"
 path = "src/cli/main.rs"
 
+
 [dependencies]
 revault_tx = { git = "https://github.com/darosior/revault", branch = "refinement" }
 
@@ -32,9 +32,8 @@ dirs = "3.0.1"
 # It's concise, does the Right Thing, and even supports Windows !
 daemonize-simple = "0.1.4"
 
-# To talk to bitcoind, the most lightweight and capable i could find without
-# reinventing the wheel. Hesitated with ureq.
-jsonrpc = { git = "https://github.com/apoelstra/rust-jsonrpc", branch = "2020-09-basic-client" }
+# To talk to bitcoind
+jsonrpc = { git = "https://github.com/stevenroose/rust-jsonrpc", branch = "transport-fixes" }
 
 # We use it for the cookie file
 base64 = "0.13.0"
@@ -42,7 +41,7 @@ base64 = "0.13.0"
 # We us TOML for the config and JSON for connections
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
-serde_json = "1.0.59"
+serde_json = { version = "1.0", features = ["raw_value"] }
 
 # Logging stuff
 log = "0.4"
@@ -55,7 +54,7 @@ rusqlite = { version = "0.24.1", features = ["bundled"] }
 # For umask..
 libc = "0.2.80"
 
-# For the JSONRPC API
+# For the JSONRPC server
 jsonrpc-core = "15.1.0"
 jsonrpc-derive = "15.1.0"
 [target.'cfg(not(windows))'.dependencies]

--- a/contrib/ci-functional-tests.sh
+++ b/contrib/ci-functional-tests.sh
@@ -16,4 +16,4 @@ python3 -m venv venv
 . venv/bin/activate
 pip install -r tests/requirements.txt
 # GA is f*ing slow. But free!
-TIMEOUT=120 TEST_DEBUG=1 pytest -vvv tests/
+TIMEOUT=120 TEST_DEBUG=1 pytest -vvv -n2 tests/

--- a/doc/API.md
+++ b/doc/API.md
@@ -128,6 +128,7 @@ either `status` or deposit `outpoints`.
 | `blockheight` | int    | Height of the block containing the transaction, `0` if unconfirmed         |
 | `psbt`        | string | base64-serialized BIP174 format of the transaction, if not fully-signed    |
 | `hex`         | string | Hexadecimal of the network-serialized transaction, if fully-signed         |
+| `received_at` | int    | Transaction reception time as UNIX epoch timestamp                         |
 
 
 ### `getrevocationtxs`

--- a/doc/API.md
+++ b/doc/API.md
@@ -8,11 +8,11 @@ Note that all addresses are bech32-encoded *version 0* native Segwit `scriptPubK
 | Command                                   | Description                                          |
 | ----------------------------------------- | ---------------------------------------------------- |
 | [`getinfo`](#getinfo)                     | Display general information                          |
-| [`listvaults`](#listvaults)               | Display a paginated list of vaults                   |
-| [`getonchaintxs`](#getonchaintxs)         | Retrieve the vault on chain transactions             |
 | [`getrevocationtxs`](#getrevocationtxs)   | Retrieve the Revault revocation transactions to sign |
 | [`getunvaulttx`](#getunvaulttx)           | Retrieve the Revault unvault transaction to sign     |
 | [`getspendtx`](#getspendtx)               | Retrieve the Revault spend transaction to sign       |
+| [`listtransactions`](#listtransactions)   | List all transactions of a specified vault           |
+| [`listvaults`](#listvaults)               | Display a paginated list of vaults                   |
 | [`revocationtxs`](#revocationtxs)         | Give back the revocation transactions signed         |
 | [`unvaulttx`](#unvaulttx)                 | Give back the unvault transaction signed             |
 | [`spendtx`](#spendtx)                     | Give back the spend transaction signed               |
@@ -81,13 +81,6 @@ Get an address to build a deposit transaction.
 Note that the `scriptPubKey` is implicitly known as we have the vault output Miniscript descriptor.
 **TODO** Maybe we should store and give the xpub derivation index as well ?
 
-### Vault Transaction resource
-
-| Field         | Type   | Description                                         |
-| ------------- | ------ | ------------------------------------------------    |
-| `blockheight` | int    | Block height of the transaction                     |
-| `hex`         | string | Hexadecimal format of the transaction               |
-| `received_at` | int    | Timestamp of the reception time of the transaction |
 
 ### `listvaults`
 
@@ -107,25 +100,35 @@ either `status` or deposit `outpoints`.
 | ------------- | ------------------------------------------ | ------------------------- |
 | `vaults`      | array of [vault resource](#vault-resource) | Vaults filtered by status |
 
-### `getonchaintxs`
 
-The `getonchaintxs` RPC Command retrieves the on chain transactions of a
-vault with the given deposit `outpoint`.
+### `listtransactions`
 
-#### Request
+| Parameter   | Type         | Description                                                                                     |
+| ----------- | ------------ | ----------------------------------------------------------------------------------------------- |
+| `outpoints` | string array | Vault IDs -- optional, filter the list with the given vault Outpoints                           |
 
-| Parameter        | Type    | Description                                     |
-| ---------------- | ------- | ----------------------------------------------- |
-| `outpoint`       | string  | Deposit outpoint of the vault                   |
+// FIXME: we could eventually also take an array of transaction types here.
 
-#### Response
+### Response
 
-| Field         | Type                                                      | Description                                                           |
-| ------------- | --------------------------------------------------------- | --------------------------------------------------------------------- |
-| `cancel_tx`   | [Vault transaction resource](#vault-transaction-resource) | Cancel transaction -- present if the vault is cancelling or cancelled |
-| `deposit_tx`  | [Vault transaction resource](#vault-transaction-resource) | Deposit transaction                                                   |
-| `spend_tx`    | [Vault transaction resource](#vault-transaction-resource) | Spend transaction -- present if vault is spending or spent            |
-| `unvault_tx`  | [Vault transaction resource](#vault-transaction-resource) | Unvault transaction -- present if vault is unvaulting or unvaulted    |
+| Field               | Type                                                 | Description                                                            |
+| ------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------  |
+| `deposit`           | [transaction resource](#transaction-resource) object | The vault deposit transaction                                          |
+| `unvault`           | [transaction resource](#transaction-resource) object | The unvaulting transaction                                             |
+| `spend`             | [transaction resource](#transaction-resource) object | The transaction spending the `unvault`ing one, only present if onchain |
+| `cancel`            | [transaction resource](#transaction-resource) object | The "revaulting" transaction                                           |
+| `emergency`         | [transaction resource](#transaction-resource) object | The emergency transaction                                              |
+| `unvault_emergency` | [transaction resource](#transaction-resource) object | The unvaulting emergency transaction                                   |
+
+
+#### Transaction resource
+
+| Field         | Type   | Description                                                                |
+| ------------- | ------ | -------------------------------------------------------------------------  |
+| `blockheight` | int    | Height of the block containing the transaction, `0` if unconfirmed         |
+| `psbt`        | string | base64-serialized BIP174 format of the transaction, if not fully-signed    |
+| `hex`         | string | Hexadecimal of the network-serialized transaction, if fully-signed         |
+
 
 ### `getrevocationtxs`
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -107,12 +107,20 @@ either `status` or deposit `outpoints`.
 | ----------- | ------------ | ----------------------------------------------------------------------------------------------- |
 | `outpoints` | string array | Vault IDs -- optional, filter the list with the given vault Outpoints                           |
 
-// FIXME: we could eventually also take an array of transaction types here.
+// FIXME: we could eventually also take an optional array of transaction types here.
 
 ### Response
 
+| Field               | Type                                                     | Description                                                                             |
+| ------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------  |
+| `transactions`      | array of [transactions resource](#transactions-resource) | The set of vaults' transactions corresponding to the query (empty on unknown outpoints) |
+
+
+#### Transactions resource
+
 | Field               | Type                                                 | Description                                                            |
 | ------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------  |
+| `outpoint`          | string                                               | The vault deposit transaction outpoint.                                |
 | `deposit`           | [transaction resource](#transaction-resource) object | The vault deposit transaction                                          |
 | `unvault`           | [transaction resource](#transaction-resource) object | The unvaulting transaction                                             |
 | `spend`             | [transaction resource](#transaction-resource) object | The transaction spending the `unvault`ing one, only present if onchain |

--- a/src/daemon/bitcoind/interface.rs
+++ b/src/daemon/bitcoind/interface.rs
@@ -5,13 +5,23 @@ use crate::{
 use common::config::BitcoindConfig;
 use revault_tx::bitcoin::{Address, Amount, BlockHash, OutPoint, TxOut, Txid};
 
-use std::{collections::HashMap, fs, str::FromStr};
+use std::{collections::HashMap, fs, str::FromStr, time::Duration};
 
-use jsonrpc::{client::Client, simple_rtt::Tripper};
+use jsonrpc::{arg, client::Client, simple_http::SimpleHttpTransport};
 
 pub struct BitcoinD {
-    node_client: Client<Tripper>,
-    watchonly_client: Client<Tripper>,
+    node_client: Client,
+    watchonly_client: Client,
+}
+
+macro_rules! params {
+    ($($param:expr),* $(,)?) => {
+        [
+            $(
+                arg($param),
+            )*
+        ]
+    };
 }
 
 impl BitcoinD {
@@ -22,17 +32,24 @@ impl BitcoinD {
         let cookie_string = fs::read_to_string(&config.cookie_path).map_err(|e| {
             BitcoindError::Custom(format!("Reading cookie file: {}", e.to_string()))
         })?;
-        // The cookie file content is "__cookie__:pass"
-        let mut cookie_slices = cookie_string.split(':');
-        let (user, pass) = (
-            cookie_slices.next().map(|s| s.to_string()),
-            cookie_slices.next().map(|s| s.to_string()),
+
+        let node_client = Client::with_transport(
+            SimpleHttpTransport::builder()
+                .url(&config.addr.to_string())
+                .map_err(BitcoindError::from)?
+                .timeout(Duration::from_secs(30))
+                .cookie_auth(cookie_string.clone())
+                .build(),
         );
-        let node_client = Client::new(format!("{}", config.addr), user.clone(), pass.clone());
-        let watchonly_client = Client::new(
-            format!("http://{}/wallet/{}", config.addr, watchonly_wallet_path),
-            user,
-            pass,
+
+        let url = format!("http://{}/wallet/{}", config.addr, watchonly_wallet_path);
+        let watchonly_client = Client::with_transport(
+            SimpleHttpTransport::builder()
+                .url(&url)
+                .map_err(BitcoindError::from)?
+                .timeout(Duration::from_secs(30))
+                .cookie_auth(cookie_string)
+                .build(),
         );
 
         Ok(BitcoinD {
@@ -51,14 +68,14 @@ impl BitcoinD {
 
     fn make_request<'a, 'b>(
         &self,
-        client: &Client<Tripper>,
+        client: &Client,
         method: &'a str,
-        params: &'b [serde_json::Value],
+        params: &'b [Box<serde_json::value::RawValue>],
     ) -> Result<serde_json::Value, BitcoindError> {
-        let req = client.build_request(method, params);
+        let req = client.build_request(method, &params);
         log::trace!("Sending to bitcoind: {:#?}", req);
-        let resp = client.send_request(&req).map_err(BitcoindError::Server)?;
-        let res = resp.into_result().map_err(BitcoindError::Server)?;
+        let resp = client.send_request(req).map_err(BitcoindError::Server)?;
+        let res = resp.result().map_err(BitcoindError::Server)?;
         log::trace!("Got from bitcoind: {:#?}", res);
 
         Ok(res)
@@ -67,7 +84,7 @@ impl BitcoinD {
     fn make_node_request<'a, 'b>(
         &self,
         method: &'a str,
-        params: &'b [serde_json::Value],
+        params: &'b [Box<serde_json::value::RawValue>],
     ) -> Result<serde_json::Value, BitcoindError> {
         self.make_request(&self.node_client, method, params)
     }
@@ -75,7 +92,7 @@ impl BitcoinD {
     fn make_watchonly_request<'a, 'b>(
         &self,
         method: &'a str,
-        params: &'b [serde_json::Value],
+        params: &'b [Box<serde_json::value::RawValue>],
     ) -> Result<serde_json::Value, BitcoindError> {
         self.make_request(&self.watchonly_client, method, params)
     }
@@ -90,7 +107,7 @@ impl BitcoinD {
             BitcoindError::Custom("API break, 'getblockcount' didn't return an u64.".to_string())
         })? as u32;
         let hash = BlockHash::from_str(
-            self.make_node_request("getblockhash", &[json_height])?
+            self.make_node_request("getblockhash", &params!(json_height))?
                 .as_str()
                 .ok_or_else(|| {
                     BitcoindError::Custom(
@@ -146,7 +163,7 @@ impl BitcoinD {
     pub fn createwallet_startup(&self, wallet_path: String) -> Result<(), BitcoindError> {
         let res = self.make_node_request(
             "createwallet",
-            &[
+            &params!(
                 serde_json::Value::String(wallet_path),
                 serde_json::Value::Bool(true),             // watchonly
                 serde_json::Value::Bool(false),            // blank
@@ -154,7 +171,7 @@ impl BitcoinD {
                 serde_json::Value::Bool(false),            // avoid_reuse
                 serde_json::Value::Bool(true),             // descriptors
                 serde_json::Value::Bool(true),             // load_on_startup
-            ],
+            ),
         )?;
 
         if res.get("name").is_some() {
@@ -193,10 +210,10 @@ impl BitcoinD {
     pub fn loadwallet_startup(&self, wallet_path: String) -> Result<(), BitcoindError> {
         let res = self.make_node_request(
             "loadwallet",
-            &[
+            &params!(
                 serde_json::Value::String(wallet_path),
                 serde_json::Value::Bool(true), // load_on_startup
-            ],
+            ),
         )?;
 
         if res.get("name").is_some() {
@@ -216,7 +233,7 @@ impl BitcoinD {
         Ok(self
             .make_watchonly_request(
                 "getdescriptorinfo",
-                &[serde_json::Value::String(desc_wo_checksum)],
+                &params!(serde_json::Value::String(desc_wo_checksum)),
             )?
             .get("descriptor")
             .ok_or_else(|| {
@@ -265,7 +282,7 @@ impl BitcoinD {
 
         let res = self.make_watchonly_request(
             "importdescriptors",
-            &[serde_json::Value::Array(all_descriptors)],
+            &params!(serde_json::Value::Array(all_descriptors)),
         )?;
         if res.get(0).map(|x| x.get("success")) == Some(Some(&serde_json::Value::Bool(true))) {
             return Ok(());
@@ -320,9 +337,9 @@ impl BitcoinD {
 
         let res = self.make_watchonly_request(
             "importdescriptors",
-            &[serde_json::Value::Array(vec![serde_json::Value::Object(
+            &params!(serde_json::Value::Array(vec![serde_json::Value::Object(
                 desc_map,
-            )])],
+            )])),
         )?;
         if res.get(0).map(|x| x.get("success")) == Some(Some(&serde_json::Value::Bool(true))) {
             return Ok(());
@@ -402,7 +419,7 @@ impl BitcoinD {
         for utxo in self
             .make_watchonly_request(
                 "listunspent",
-                &[serde_json::Value::Number(serde_json::Number::from(0))], // minconf
+                &params!(serde_json::Value::Number(serde_json::Number::from(0))), // minconf
             )?
             .as_array()
             .ok_or_else(|| {
@@ -515,7 +532,7 @@ impl BitcoinD {
     ) -> Result<(String, Option<u32>), BitcoindError> {
         let res = self.make_watchonly_request(
             "gettransaction",
-            &[serde_json::Value::String(txid.to_string())],
+            &params!(serde_json::Value::String(txid.to_string())),
         )?;
         let tx_hex = res
             .get("hex")
@@ -540,11 +557,11 @@ impl BitcoinD {
         Ok(self
             .make_watchonly_request(
                 "gettransaction",
-                &[
+                &params!(
                     serde_json::Value::String(outpoint.txid.to_string()),
                     serde_json::Value::Bool(true), // include_watchonly
                     serde_json::Value::Bool(true), // verbose
-                ],
+                ),
             )?
             .get("decoded")
             .ok_or_else(|| {
@@ -582,11 +599,11 @@ impl BitcoinD {
     ) -> Result<Option<OutPoint>, BitcoindError> {
         let res = self.make_watchonly_request(
             "listunspent",
-            &[
+            &params!(
                 serde_json::Value::Number(serde_json::Number::from(0)), // minconf
                 serde_json::Value::Number(serde_json::Number::from(9999999)), // maxconf (default)
                 serde_json::Value::Array(vec![serde_json::Value::String(unvault_address)]),
-            ],
+            ),
         )?;
         let utxos = res.as_array().ok_or_else(|| {
             BitcoindError::Custom("API break: 'listunspent' didn't return an array".to_string())

--- a/src/daemon/bitcoind/mod.rs
+++ b/src/daemon/bitcoind/mod.rs
@@ -1,6 +1,9 @@
 use crate::database::DatabaseError;
 
-use jsonrpc::error::{Error, RpcError};
+use jsonrpc::{
+    error::{Error, RpcError},
+    simple_http,
+};
 
 pub mod actions;
 pub mod interface;
@@ -42,5 +45,11 @@ impl std::error::Error for BitcoindError {}
 impl From<DatabaseError> for BitcoindError {
     fn from(e: DatabaseError) -> Self {
         Self::Custom(format!("Database error in bitcoind thread: {}", e))
+    }
+}
+
+impl From<simple_http::Error> for BitcoindError {
+    fn from(e: simple_http::Error) -> Self {
+        Self::Server(Error::Transport(Box::new(e)))
     }
 }

--- a/src/daemon/jsonrpc/api.rs
+++ b/src/daemon/jsonrpc/api.rs
@@ -67,12 +67,13 @@ pub trait RpcApi {
     #[rpc(meta, name = "getdepositaddress")]
     fn getdepositaddress(&self, meta: Self::Metadata) -> jsonrpc_core::Result<serde_json::Value>;
 
-    /// Get the cancel and both emergency transactions for a vault identified by deposit txid.
+    /// Get the cancel and both emergency transactions for a vault identified by its deposit
+    /// outpoint.
     #[rpc(meta, name = "getrevocationtxs")]
     fn getrevocationtxs(
         &self,
         meta: Self::Metadata,
-        txid: String,
+        outpoint: String,
     ) -> jsonrpc_core::Result<serde_json::Value>;
 
     /// Retrieve the onchain transactions of a vault with the given deposit outpoint

--- a/src/daemon/jsonrpc/mod.rs
+++ b/src/daemon/jsonrpc/mod.rs
@@ -333,6 +333,7 @@ pub fn jsonrpcapi_loop(tx: Sender<RpcMessageIn>, listener: UnixListener) -> Resu
     jsonrpc_io.extend_with(RpcImpl.to_delegate());
     let metadata = JsonRpcMetaData::from_tx(tx);
 
+    log::info!("JSONRPC server started.");
     #[cfg(not(windows))]
     return mio_loop(listener, jsonrpc_io, metadata);
     #[cfg(windows)]

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -8,7 +8,7 @@ use crate::{
     bitcoind::actions::{bitcoind_main_loop, start_bitcoind},
     database::{
         actions::setup_db,
-        interface::{db_tip, db_transactions, db_vault_by_deposit, RevaultTx},
+        interface::{db_deposits, db_tip, db_transactions, db_vault_by_deposit, RevaultTx},
     },
     jsonrpc::{jsonrpcapi_loop, jsonrpcapi_setup},
     revaultd::{BlockchainTip, RevaultD, VaultStatus},
@@ -290,211 +290,225 @@ fn daemon_main(mut revaultd: RevaultD) {
                     });
                 }
             }
-            RpcMessageIn::ListTransactions(outpoint, response_tx) => {
+            RpcMessageIn::ListTransactions(outpoints, response_tx) => {
                 log::trace!("Got 'listtransactions' request from RPC thread");
                 let revaultd = revaultd.read().unwrap();
                 let xpub_ctx = revaultd.xpub_ctx();
 
-                let transactions = if let Some(vault) = revaultd.vaults.get(&outpoint) {
-                    let db_vault = db_vault_by_deposit(&db_path, &outpoint)
+                // If they didn't provide us with a list of outpoints, catch'em all!
+                let outpoints = outpoints.unwrap_or_else(|| {
+                    db_deposits(&db_path)
                         .unwrap_or_else(|e| {
-                            log::error!("Getting vault from db: {}", e);
+                            log::error!("Getting deposits from db: {}", e);
                             process::exit(1);
                         })
-                        .unwrap_or_else(|| {
-                            log::error!("(Insane db) None vault for '{}'", &outpoint);
-                            process::exit(1);
-                        });
-                    let mut txs = db_transactions(&db_path, db_vault.id, &[])
-                        .unwrap_or_else(|e| {
-                            log::error!("Getting transactions (all) from db: {}", e);
-                            process::exit(1);
-                        })
-                        .into_iter();
+                        .into_iter()
+                        .map(|db_vault| db_vault.deposit_outpoint)
+                        .collect()
+                });
 
-                    let deposit_tx = txs
-                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::Deposit(_)))
-                        .map(|tx| assert_tx_type!(tx.tx, Deposit, "We just found it"))
-                        .unwrap_or_else(|| {
-                            log::error!("Vault without deposit tx in db for {}", outpoint);
-                            process::exit(1);
-                        });
-                    let wallet_tx = bitcoind_wallet_tx(&bitcoind_tx, deposit_tx.0.txid());
-                    let deposit = TransactionResource {
-                        wallet_tx,
-                        tx: deposit_tx,
-                        // The deposit is always signed, if we heard about it in
-                        // the first place
-                        is_signed: true,
-                    };
-
-                    // Get the descriptors in case we need to derive the transactions (not signed
-                    // yet, ie not in DB).
-                    // One day, we could try to be smarter wrt free derivation but it's not
-                    // a priority atm.
-                    let index = revaultd
-                        .derivation_index_map
-                        .get(&vault.txo.script_pubkey)
-                        .unwrap_or_else(|| {
-                            log::error!("Unknown derivation index for: {:#?}", vault);
-                            process::exit(1);
-                        });
-                    let deposit_descriptor = revaultd.vault_descriptor.derive(*index);
-                    let vault_txin = VaultTxIn::new(
-                        outpoint,
-                        VaultTxOut::new(vault.txo.value, &deposit_descriptor, xpub_ctx),
-                    );
-                    let unvault_descriptor = revaultd.unvault_descriptor.derive(*index);
-                    let cpfp_descriptor = revaultd.cpfp_descriptor.derive(*index);
-                    let emer_address = revaultd.emergency_address.clone();
-
-                    // We can always re-generate the Unvault out of the descriptor if it's
-                    // not in DB..
-                    let mut unvault_tx = txs
-                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::Unvault(_)))
-                        .map(|tx| assert_tx_type!(tx.tx, Unvault, "We just found it"))
-                        .unwrap_or_else(|| {
-                            UnvaultTransaction::new(
-                                vault_txin.clone(),
-                                &unvault_descriptor,
-                                &cpfp_descriptor,
-                                xpub_ctx,
-                                revaultd.lock_time,
-                            )
+                let mut vaults = Vec::with_capacity(outpoints.len());
+                for outpoint in outpoints {
+                    if let Some(vault) = revaultd.vaults.get(&outpoint) {
+                        let db_vault = db_vault_by_deposit(&db_path, &outpoint)
                             .unwrap_or_else(|e| {
-                                log::error!("Deriving unvault for '{}': {}", outpoint, e);
+                                log::error!("Getting vault from db: {}", e);
                                 process::exit(1);
                             })
-                        });
-                    let unvault_txin = unvault_tx
-                        .unvault_txin(&unvault_descriptor, xpub_ctx, revaultd.unvault_csv)
-                        .expect("Just created it");
-                    let wallet_tx = bitcoind_wallet_tx(
-                        &bitcoind_tx,
-                        unvault_tx.inner_tx().global.unsigned_tx.txid(),
-                    );
-                    // The transaction is signed if we did sign it, or if others did (eg
-                    // non-stakeholder managers) and we noticed it from broadcast.
-                    // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
-                    let is_signed =
-                        unvault_tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
-                    let unvault = TransactionResource {
-                        wallet_tx,
-                        tx: unvault_tx,
-                        is_signed,
-                    };
+                            .unwrap_or_else(|| {
+                                log::error!("(Insane db) None vault for '{}'", &outpoint);
+                                process::exit(1);
+                            });
+                        let mut txs = db_transactions(&db_path, db_vault.id, &[])
+                            .unwrap_or_else(|e| {
+                                log::error!("Getting transactions (all) from db: {}", e);
+                                process::exit(1);
+                            })
+                            .into_iter();
 
-                    // .. But not the spend, as it's dynamically chosen by the managers and
-                    // could be anything!
-                    let spend = if let Some(mut tx) = txs
-                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::Spend(_)))
-                        .map(|tx| assert_tx_type!(tx.tx, Spend, "We just found it"))
-                    {
+                        let deposit_tx = txs
+                            .find(|db_tx| matches!(db_tx.tx, RevaultTx::Deposit(_)))
+                            .map(|tx| assert_tx_type!(tx.tx, Deposit, "We just found it"))
+                            .unwrap_or_else(|| {
+                                log::error!("Vault without deposit tx in db for {}", outpoint);
+                                process::exit(1);
+                            });
+                        let wallet_tx = bitcoind_wallet_tx(&bitcoind_tx, deposit_tx.0.txid());
+                        let deposit = TransactionResource {
+                            wallet_tx,
+                            tx: deposit_tx,
+                            // The deposit is always signed, if we heard about it in
+                            // the first place
+                            is_signed: true,
+                        };
+
+                        // Get the descriptors in case we need to derive the transactions (not signed
+                        // yet, ie not in DB).
+                        // One day, we could try to be smarter wrt free derivation but it's not
+                        // a priority atm.
+                        let index = revaultd
+                            .derivation_index_map
+                            .get(&vault.txo.script_pubkey)
+                            .unwrap_or_else(|| {
+                                log::error!("Unknown derivation index for: {:#?}", vault);
+                                process::exit(1);
+                            });
+                        let deposit_descriptor = revaultd.vault_descriptor.derive(*index);
+                        let vault_txin = VaultTxIn::new(
+                            outpoint,
+                            VaultTxOut::new(vault.txo.value, &deposit_descriptor, xpub_ctx),
+                        );
+                        let unvault_descriptor = revaultd.unvault_descriptor.derive(*index);
+                        let cpfp_descriptor = revaultd.cpfp_descriptor.derive(*index);
+                        let emer_address = revaultd.emergency_address.clone();
+
+                        // We can always re-generate the Unvault out of the descriptor if it's
+                        // not in DB..
+                        let mut unvault_tx = txs
+                            .find(|db_tx| matches!(db_tx.tx, RevaultTx::Unvault(_)))
+                            .map(|tx| assert_tx_type!(tx.tx, Unvault, "We just found it"))
+                            .unwrap_or_else(|| {
+                                UnvaultTransaction::new(
+                                    vault_txin.clone(),
+                                    &unvault_descriptor,
+                                    &cpfp_descriptor,
+                                    xpub_ctx,
+                                    revaultd.lock_time,
+                                )
+                                .unwrap_or_else(|e| {
+                                    log::error!("Deriving unvault for '{}': {}", outpoint, e);
+                                    process::exit(1);
+                                })
+                            });
+                        let unvault_txin = unvault_tx
+                            .unvault_txin(&unvault_descriptor, xpub_ctx, revaultd.unvault_csv)
+                            .expect("Just created it");
                         let wallet_tx = bitcoind_wallet_tx(
                             &bitcoind_tx,
-                            tx.inner_tx().global.unsigned_tx.txid(),
+                            unvault_tx.inner_tx().global.unsigned_tx.txid(),
+                        );
+                        // The transaction is signed if we did sign it, or if others did (eg
+                        // non-stakeholder managers) and we noticed it from broadcast.
+                        // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
+                        let is_signed =
+                            unvault_tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
+                        let unvault = TransactionResource {
+                            wallet_tx,
+                            tx: unvault_tx,
+                            is_signed,
+                        };
+
+                        // .. But not the spend, as it's dynamically chosen by the managers and
+                        // could be anything!
+                        let spend = if let Some(mut tx) = txs
+                            .find(|db_tx| matches!(db_tx.tx, RevaultTx::Spend(_)))
+                            .map(|tx| assert_tx_type!(tx.tx, Spend, "We just found it"))
+                        {
+                            let wallet_tx = bitcoind_wallet_tx(
+                                &bitcoind_tx,
+                                tx.inner_tx().global.unsigned_tx.txid(),
+                            );
+                            // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
+                            let is_signed =
+                                tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
+                            Some(TransactionResource {
+                                wallet_tx,
+                                tx,
+                                is_signed,
+                            })
+                        } else {
+                            None
+                        };
+
+                        // The cancel transaction is deterministic, so we can always return it.
+                        let mut cancel_tx = txs
+                            .find(|db_tx| matches!(db_tx.tx, RevaultTx::Cancel(_)))
+                            .map(|tx| assert_tx_type!(tx.tx, Cancel, "We just found it"))
+                            .unwrap_or_else(|| {
+                                CancelTransaction::new(
+                                    unvault_txin.clone(),
+                                    None,
+                                    &deposit_descriptor,
+                                    xpub_ctx,
+                                    revaultd.lock_time,
+                                )
+                            });
+                        let wallet_tx = bitcoind_wallet_tx(
+                            &bitcoind_tx,
+                            cancel_tx.inner_tx().global.unsigned_tx.txid(),
                         );
                         // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
                         let is_signed =
-                            tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
-                        Some(TransactionResource {
+                            cancel_tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
+                        let cancel = TransactionResource {
                             wallet_tx,
-                            tx,
+                            tx: cancel_tx,
                             is_signed,
-                        })
-                    } else {
-                        None
-                    };
+                        };
 
-                    // The cancel transaction is deterministic, so we can always return it.
-                    let mut cancel_tx = txs
-                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::Cancel(_)))
-                        .map(|tx| assert_tx_type!(tx.tx, Cancel, "We just found it"))
-                        .unwrap_or_else(|| {
-                            CancelTransaction::new(
-                                unvault_txin.clone(),
-                                None,
-                                &deposit_descriptor,
-                                xpub_ctx,
-                                revaultd.lock_time,
-                            )
+                        // The emergency transaction is deterministic, so we can always return it.
+                        let mut emergency_tx = txs
+                            .find(|db_tx| matches!(db_tx.tx, RevaultTx::Emergency(_)))
+                            .map(|tx| assert_tx_type!(tx.tx, Emergency, "We just found it"))
+                            .unwrap_or_else(|| {
+                                EmergencyTransaction::new(
+                                    vault_txin,
+                                    None,
+                                    emer_address,
+                                    revaultd.lock_time,
+                                )
+                            });
+                        let wallet_tx = bitcoind_wallet_tx(
+                            &bitcoind_tx,
+                            emergency_tx.inner_tx().global.unsigned_tx.txid(),
+                        );
+                        // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
+                        let is_signed = emergency_tx.finalize(&revaultd.secp_ctx).is_ok()
+                            || wallet_tx.is_some();
+                        let emergency = TransactionResource {
+                            wallet_tx,
+                            tx: emergency_tx,
+                            is_signed,
+                        };
+
+                        // Same for the second emergency.
+                        let mut unvault_emergency_tx = txs
+                            .find(|db_tx| matches!(db_tx.tx, RevaultTx::UnvaultEmergency(_)))
+                            .map(|tx| assert_tx_type!(tx.tx, UnvaultEmergency, "We just found it"))
+                            .unwrap_or_else(|| {
+                                UnvaultEmergencyTransaction::new(
+                                    unvault_txin,
+                                    None,
+                                    revaultd.emergency_address.clone(),
+                                    revaultd.lock_time,
+                                )
+                            });
+                        let wallet_tx = bitcoind_wallet_tx(
+                            &bitcoind_tx,
+                            unvault_emergency_tx.inner_tx().global.unsigned_tx.txid(),
+                        );
+                        // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
+                        let is_signed = unvault_emergency_tx.finalize(&revaultd.secp_ctx).is_ok()
+                            || wallet_tx.is_some();
+                        let unvault_emergency = TransactionResource {
+                            wallet_tx,
+                            tx: unvault_emergency_tx,
+                            is_signed,
+                        };
+
+                        vaults.push(VaultTransactions {
+                            outpoint,
+                            deposit,
+                            unvault,
+                            spend,
+                            cancel,
+                            emergency,
+                            unvault_emergency,
                         });
-                    let wallet_tx = bitcoind_wallet_tx(
-                        &bitcoind_tx,
-                        cancel_tx.inner_tx().global.unsigned_tx.txid(),
-                    );
-                    // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
-                    let is_signed =
-                        cancel_tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
-                    let cancel = TransactionResource {
-                        wallet_tx,
-                        tx: cancel_tx,
-                        is_signed,
-                    };
+                    }
+                }
 
-                    // The emergency transaction is deterministic, so we can always return it.
-                    let mut emergency_tx = txs
-                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::Emergency(_)))
-                        .map(|tx| assert_tx_type!(tx.tx, Emergency, "We just found it"))
-                        .unwrap_or_else(|| {
-                            EmergencyTransaction::new(
-                                vault_txin,
-                                None,
-                                emer_address,
-                                revaultd.lock_time,
-                            )
-                        });
-                    let wallet_tx = bitcoind_wallet_tx(
-                        &bitcoind_tx,
-                        emergency_tx.inner_tx().global.unsigned_tx.txid(),
-                    );
-                    // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
-                    let is_signed =
-                        emergency_tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
-                    let emergency = TransactionResource {
-                        wallet_tx,
-                        tx: emergency_tx,
-                        is_signed,
-                    };
-
-                    // Same for the second emergency.
-                    let mut unvault_emergency_tx = txs
-                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::UnvaultEmergency(_)))
-                        .map(|tx| assert_tx_type!(tx.tx, UnvaultEmergency, "We just found it"))
-                        .unwrap_or_else(|| {
-                            UnvaultEmergencyTransaction::new(
-                                unvault_txin,
-                                None,
-                                revaultd.emergency_address.clone(),
-                                revaultd.lock_time,
-                            )
-                        });
-                    let wallet_tx = bitcoind_wallet_tx(
-                        &bitcoind_tx,
-                        unvault_emergency_tx.inner_tx().global.unsigned_tx.txid(),
-                    );
-                    // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
-                    let is_signed = unvault_emergency_tx.finalize(&revaultd.secp_ctx).is_ok()
-                        || wallet_tx.is_some();
-                    let unvault_emergency = TransactionResource {
-                        wallet_tx,
-                        tx: unvault_emergency_tx,
-                        is_signed,
-                    };
-
-                    Some(VaultTransactions {
-                        deposit,
-                        unvault,
-                        spend,
-                        cancel,
-                        emergency,
-                        unvault_emergency,
-                    })
-                } else {
-                    None
-                };
-
-                response_tx.send(transactions).unwrap_or_else(|e| {
+                response_tx.send(vaults).unwrap_or_else(|e| {
                     log::error!("Sending 'listtransactions' result to RPC thread: {}", e);
                     process::exit(1);
                 });

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -6,20 +6,34 @@ mod threadmessages;
 
 use crate::{
     bitcoind::actions::{bitcoind_main_loop, start_bitcoind},
-    database::{actions::setup_db, interface::db_tip},
+    database::{
+        actions::setup_db,
+        interface::{db_tip, db_transactions, db_vault_by_deposit, RevaultTx},
+    },
     jsonrpc::{jsonrpcapi_loop, jsonrpcapi_setup},
     revaultd::{BlockchainTip, RevaultD, VaultStatus},
     threadmessages::*,
 };
 use common::config::Config;
-use revault_tx::{transactions::transaction_chain, txins::VaultTxIn, txouts::VaultTxOut};
+use revault_tx::{
+    bitcoin::Txid,
+    transactions::{
+        transaction_chain, CancelTransaction, EmergencyTransaction, RevaultTransaction,
+        UnvaultEmergencyTransaction, UnvaultTransaction,
+    },
+    txins::VaultTxIn,
+    txouts::VaultTxOut,
+};
 
 use std::{
     env,
     path::PathBuf,
     process,
     str::FromStr,
-    sync::{mpsc, Arc, RwLock},
+    sync::{
+        mpsc::{self, Sender},
+        Arc, RwLock,
+    },
     thread,
 };
 
@@ -37,6 +51,28 @@ fn parse_args(args: Vec<String>) -> Option<PathBuf> {
     }
 
     Some(PathBuf::from(args[2].to_owned()))
+}
+
+fn bitcoind_wallet_tx(
+    bitcoind_tx: &Sender<BitcoindMessageOut>,
+    txid: Txid,
+) -> Option<WalletTransaction> {
+    log::trace!("Sending WalletTx to bitcoind thread for {}", txid);
+
+    let (bitrep_tx, bitrep_rx) = mpsc::sync_channel(0);
+    bitcoind_tx
+        .send(BitcoindMessageOut::WalletTransaction(txid, bitrep_tx))
+        .unwrap_or_else(|e| {
+            log::error!("Sending 'wallettransaction' to bitcoind thread: {:?}", e);
+            process::exit(1);
+        });
+    bitrep_rx.recv().unwrap_or_else(|e| {
+        log::error!(
+            "Receiving 'wallettransaction' from bitcoind thread: {:?}",
+            e
+        );
+        process::exit(1);
+    })
 }
 
 fn daemon_main(mut revaultd: RevaultD) {
@@ -253,6 +289,215 @@ fn daemon_main(mut revaultd: RevaultD) {
                         process::exit(1);
                     });
                 }
+            }
+            RpcMessageIn::ListTransactions(outpoint, response_tx) => {
+                log::trace!("Got 'listtransactions' request from RPC thread");
+                let revaultd = revaultd.read().unwrap();
+                let xpub_ctx = revaultd.xpub_ctx();
+
+                let transactions = if let Some(vault) = revaultd.vaults.get(&outpoint) {
+                    let db_vault = db_vault_by_deposit(&db_path, &outpoint)
+                        .unwrap_or_else(|e| {
+                            log::error!("Getting vault from db: {}", e);
+                            process::exit(1);
+                        })
+                        .unwrap_or_else(|| {
+                            log::error!("(Insane db) None vault for '{}'", &outpoint);
+                            process::exit(1);
+                        });
+                    let mut txs = db_transactions(&db_path, db_vault.id, &[])
+                        .unwrap_or_else(|e| {
+                            log::error!("Getting transactions (all) from db: {}", e);
+                            process::exit(1);
+                        })
+                        .into_iter();
+
+                    let deposit_tx = txs
+                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::Deposit(_)))
+                        .map(|tx| assert_tx_type!(tx.tx, Deposit, "We just found it"))
+                        .unwrap_or_else(|| {
+                            log::error!("Vault without deposit tx in db for {}", outpoint);
+                            process::exit(1);
+                        });
+                    let wallet_tx = bitcoind_wallet_tx(&bitcoind_tx, deposit_tx.0.txid());
+                    let deposit = TransactionResource {
+                        wallet_tx,
+                        tx: deposit_tx,
+                        // The deposit is always signed, if we heard about it in
+                        // the first place
+                        is_signed: true,
+                    };
+
+                    // Get the descriptors in case we need to derive the transactions (not signed
+                    // yet, ie not in DB).
+                    // One day, we could try to be smarter wrt free derivation but it's not
+                    // a priority atm.
+                    let index = revaultd
+                        .derivation_index_map
+                        .get(&vault.txo.script_pubkey)
+                        .unwrap_or_else(|| {
+                            log::error!("Unknown derivation index for: {:#?}", vault);
+                            process::exit(1);
+                        });
+                    let deposit_descriptor = revaultd.vault_descriptor.derive(*index);
+                    let vault_txin = VaultTxIn::new(
+                        outpoint,
+                        VaultTxOut::new(vault.txo.value, &deposit_descriptor, xpub_ctx),
+                    );
+                    let unvault_descriptor = revaultd.unvault_descriptor.derive(*index);
+                    let cpfp_descriptor = revaultd.cpfp_descriptor.derive(*index);
+                    let emer_address = revaultd.emergency_address.clone();
+
+                    // We can always re-generate the Unvault out of the descriptor if it's
+                    // not in DB..
+                    let mut unvault_tx = txs
+                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::Unvault(_)))
+                        .map(|tx| assert_tx_type!(tx.tx, Unvault, "We just found it"))
+                        .unwrap_or_else(|| {
+                            UnvaultTransaction::new(
+                                vault_txin.clone(),
+                                &unvault_descriptor,
+                                &cpfp_descriptor,
+                                xpub_ctx,
+                                revaultd.lock_time,
+                            )
+                            .unwrap_or_else(|e| {
+                                log::error!("Deriving unvault for '{}': {}", outpoint, e);
+                                process::exit(1);
+                            })
+                        });
+                    let unvault_txin = unvault_tx
+                        .unvault_txin(&unvault_descriptor, xpub_ctx, revaultd.unvault_csv)
+                        .expect("Just created it");
+                    let wallet_tx = bitcoind_wallet_tx(
+                        &bitcoind_tx,
+                        unvault_tx.inner_tx().global.unsigned_tx.txid(),
+                    );
+                    // The transaction is signed if we did sign it, or if others did (eg
+                    // non-stakeholder managers) and we noticed it from broadcast.
+                    // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
+                    let is_signed =
+                        unvault_tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
+                    let unvault = TransactionResource {
+                        wallet_tx,
+                        tx: unvault_tx,
+                        is_signed,
+                    };
+
+                    // .. But not the spend, as it's dynamically chosen by the managers and
+                    // could be anything!
+                    let spend = if let Some(mut tx) = txs
+                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::Spend(_)))
+                        .map(|tx| assert_tx_type!(tx.tx, Spend, "We just found it"))
+                    {
+                        let wallet_tx = bitcoind_wallet_tx(
+                            &bitcoind_tx,
+                            tx.inner_tx().global.unsigned_tx.txid(),
+                        );
+                        // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
+                        let is_signed =
+                            tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
+                        Some(TransactionResource {
+                            wallet_tx,
+                            tx,
+                            is_signed,
+                        })
+                    } else {
+                        None
+                    };
+
+                    // The cancel transaction is deterministic, so we can always return it.
+                    let mut cancel_tx = txs
+                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::Cancel(_)))
+                        .map(|tx| assert_tx_type!(tx.tx, Cancel, "We just found it"))
+                        .unwrap_or_else(|| {
+                            CancelTransaction::new(
+                                unvault_txin.clone(),
+                                None,
+                                &deposit_descriptor,
+                                xpub_ctx,
+                                revaultd.lock_time,
+                            )
+                        });
+                    let wallet_tx = bitcoind_wallet_tx(
+                        &bitcoind_tx,
+                        cancel_tx.inner_tx().global.unsigned_tx.txid(),
+                    );
+                    // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
+                    let is_signed =
+                        cancel_tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
+                    let cancel = TransactionResource {
+                        wallet_tx,
+                        tx: cancel_tx,
+                        is_signed,
+                    };
+
+                    // The emergency transaction is deterministic, so we can always return it.
+                    let mut emergency_tx = txs
+                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::Emergency(_)))
+                        .map(|tx| assert_tx_type!(tx.tx, Emergency, "We just found it"))
+                        .unwrap_or_else(|| {
+                            EmergencyTransaction::new(
+                                vault_txin,
+                                None,
+                                emer_address,
+                                revaultd.lock_time,
+                            )
+                        });
+                    let wallet_tx = bitcoind_wallet_tx(
+                        &bitcoind_tx,
+                        emergency_tx.inner_tx().global.unsigned_tx.txid(),
+                    );
+                    // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
+                    let is_signed =
+                        emergency_tx.finalize(&revaultd.secp_ctx).is_ok() || wallet_tx.is_some();
+                    let emergency = TransactionResource {
+                        wallet_tx,
+                        tx: emergency_tx,
+                        is_signed,
+                    };
+
+                    // Same for the second emergency.
+                    let mut unvault_emergency_tx = txs
+                        .find(|db_tx| matches!(db_tx.tx, RevaultTx::UnvaultEmergency(_)))
+                        .map(|tx| assert_tx_type!(tx.tx, UnvaultEmergency, "We just found it"))
+                        .unwrap_or_else(|| {
+                            UnvaultEmergencyTransaction::new(
+                                unvault_txin,
+                                None,
+                                revaultd.emergency_address.clone(),
+                                revaultd.lock_time,
+                            )
+                        });
+                    let wallet_tx = bitcoind_wallet_tx(
+                        &bitcoind_tx,
+                        unvault_emergency_tx.inner_tx().global.unsigned_tx.txid(),
+                    );
+                    // TODO: maybe a is_finalizable upstream ? finalize() is pretty costy
+                    let is_signed = unvault_emergency_tx.finalize(&revaultd.secp_ctx).is_ok()
+                        || wallet_tx.is_some();
+                    let unvault_emergency = TransactionResource {
+                        wallet_tx,
+                        tx: unvault_emergency_tx,
+                        is_signed,
+                    };
+
+                    Some(VaultTransactions {
+                        deposit,
+                        unvault,
+                        spend,
+                        cancel,
+                        emergency,
+                        unvault_emergency,
+                    })
+                } else {
+                    None
+                };
+
+                response_tx.send(transactions).unwrap_or_else(|e| {
+                    log::error!("Sending 'listtransactions' result to RPC thread: {}", e);
+                    process::exit(1);
+                });
             }
         }
     }

--- a/src/daemon/revaultd.rs
+++ b/src/daemon/revaultd.rs
@@ -37,10 +37,14 @@ pub enum VaultStatus {
     Canceling,
     /// The cancel transaction is confirmed
     Canceled,
-    /// One of the emergency transactions has been broadcast
+    /// The first emergency transactions has been broadcast
     EmergencyVaulting,
-    /// One of the emergency transactions is confirmed
+    /// The first emergency transactions is confirmed
     EmergencyVaulted,
+    /// The unvault emergency transactions has been broadcast
+    UnvaultEmergencyVaulting,
+    /// The unvault emergency transactions is confirmed
+    UnvaultEmergencyVaulted,
     /// The unvault transaction CSV is expired
     Spendable,
     /// The spend transaction has been broadcast
@@ -65,9 +69,11 @@ impl TryFrom<u32> for VaultStatus {
             7 => Ok(Self::Canceled),
             8 => Ok(Self::EmergencyVaulting),
             9 => Ok(Self::EmergencyVaulted),
-            10 => Ok(Self::Spendable),
-            11 => Ok(Self::Spending),
-            12 => Ok(Self::Spent),
+            10 => Ok(Self::UnvaultEmergencyVaulting),
+            11 => Ok(Self::UnvaultEmergencyVaulted),
+            12 => Ok(Self::Spendable),
+            13 => Ok(Self::Spending),
+            14 => Ok(Self::Spent),
             _ => Err(()),
         }
     }
@@ -88,6 +94,8 @@ impl FromStr for VaultStatus {
             "canceled" => Ok(Self::Canceled),
             "emergencyvaulting" => Ok(Self::EmergencyVaulting),
             "emergencyvaulted" => Ok(Self::EmergencyVaulted),
+            "unvaultermergencyvaulting" => Ok(Self::UnvaultEmergencyVaulting),
+            "unvaultermergencyvaulted" => Ok(Self::UnvaultEmergencyVaulted),
             "spendable" => Ok(Self::Spendable),
             "spending" => Ok(Self::Spending),
             "spent" => Ok(Self::Spent),
@@ -112,6 +120,8 @@ impl fmt::Display for VaultStatus {
                 Self::Canceled => "canceled",
                 Self::EmergencyVaulting => "emergencyvaulting",
                 Self::EmergencyVaulted => "emergencyvaulted",
+                Self::UnvaultEmergencyVaulting => "unvaultermergencyvaulting",
+                Self::UnvaultEmergencyVaulted => "unvaultermergencyvaulted",
                 Self::Spendable => "spendable",
                 Self::Spending => "spending",
                 Self::Spent => "spent",

--- a/src/daemon/threadmessages.rs
+++ b/src/daemon/threadmessages.rs
@@ -33,10 +33,10 @@ pub enum RpcMessageIn {
         >,
     ),
     ListTransactions(
-        OutPoint,
+        Option<Vec<OutPoint>>,
         SyncSender<
             // None if the deposit does not exist
-            Option<VaultTransactions>,
+            Vec<VaultTransactions>,
         >,
     ),
 }
@@ -66,6 +66,7 @@ pub struct TransactionResource<T> {
 
 #[derive(Debug)]
 pub struct VaultTransactions {
+    pub outpoint: OutPoint,
     pub deposit: TransactionResource<VaultTransaction>,
     pub unvault: TransactionResource<UnvaultTransaction>,
     // None if not spending

--- a/src/daemon/threadmessages.rs
+++ b/src/daemon/threadmessages.rs
@@ -1,7 +1,10 @@
 use crate::revaultd::VaultStatus;
 use revault_tx::{
-    bitcoin::{Address, OutPoint},
-    transactions::{CancelTransaction, EmergencyTransaction, UnvaultEmergencyTransaction},
+    bitcoin::{Address, OutPoint, Txid},
+    transactions::{
+        CancelTransaction, EmergencyTransaction, SpendTransaction, UnvaultEmergencyTransaction,
+        UnvaultTransaction, VaultTransaction,
+    },
 };
 
 use std::sync::mpsc::SyncSender;
@@ -29,6 +32,13 @@ pub enum RpcMessageIn {
             )>,
         >,
     ),
+    ListTransactions(
+        OutPoint,
+        SyncSender<
+            // None if the deposit does not exist
+            Option<VaultTransactions>,
+        >,
+    ),
 }
 
 /// Outgoing to the bitcoind poller thread
@@ -36,4 +46,31 @@ pub enum RpcMessageIn {
 pub enum BitcoindMessageOut {
     Shutdown,
     SyncProgress(SyncSender<f64>),
+    WalletTransaction(Txid, SyncSender<Option<WalletTransaction>>),
+}
+
+#[derive(Debug)]
+pub struct WalletTransaction {
+    pub hex: String,
+    pub blockheight: Option<u32>,
+    pub received_time: u32,
+}
+
+#[derive(Debug)]
+pub struct TransactionResource<T> {
+    // None if unconfirmed
+    pub wallet_tx: Option<WalletTransaction>,
+    pub tx: T,
+    pub is_signed: bool,
+}
+
+#[derive(Debug)]
+pub struct VaultTransactions {
+    pub deposit: TransactionResource<VaultTransaction>,
+    pub unvault: TransactionResource<UnvaultTransaction>,
+    // None if not spending
+    pub spend: Option<TransactionResource<SpendTransaction>>,
+    pub cancel: TransactionResource<CancelTransaction>,
+    pub emergency: TransactionResource<EmergencyTransaction>,
+    pub unvault_emergency: TransactionResource<UnvaultEmergencyTransaction>,
 }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -9,6 +9,7 @@ import os
 import pytest
 import shutil
 import tempfile
+import time
 
 __attempts = {}
 
@@ -65,6 +66,9 @@ def bitcoind(directory):
 
     while bitcoind.rpc.getbalance() < 50:
         bitcoind.rpc.generatetoaddress(1, bitcoind.rpc.getnewaddress())
+
+    while bitcoind.rpc.getblockcount() <= 1:
+        time.sleep(0.1)
 
     yield bitcoind
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -151,10 +151,12 @@ def test_listtransactions(revaultd_factory, bitcoind):
     vault = stks[0].rpc.call("listvaults")["vaults"][0]
     deposit = f"{vault['txid']}:{vault['vout']}"
 
-    res = stks[0].rpc.listtransactions(deposit)
+    res = stks[0].rpc.listtransactions([deposit])["transactions"][0]
     # Sanity check the API
     assert ("deposit" in res and "unvault" in res and "cancel" in res
             and "emergency" in res and "unvault_emergency" in res)
+    assert (stks[0].rpc.listtransactions([deposit]) ==
+            stks[0].rpc.listtransactions())
     # The deposit is always fully signed..
     assert "hex" in res["deposit"]
     # .. And broadcast
@@ -165,11 +167,11 @@ def test_listtransactions(revaultd_factory, bitcoind):
     # Get it confirmed
     bitcoind.generate_block(6, txid)
     wait_for(lambda: stks[0].rpc.listvaults()["vaults"][0]["status"] == "funded")
-    res = stks[0].rpc.listtransactions(deposit)
+    res = stks[0].rpc.listtransactions([deposit])["transactions"][0]
     assert "blockheight" in res["deposit"]
 
     # Sanity check they all output the same transactions..
     sorted_res = sorted(res.items())
     for n in stks[1:] + mans:
-        res = n.rpc.listtransactions(deposit)
+        res = n.rpc.listtransactions([deposit])["transactions"][0]
         assert sorted(res.items()) == sorted_res

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -596,9 +596,9 @@ class RevaultD(TailableProc):
 
     def start(self):
         TailableProc.start(self)
-        self.wait_for_log("revaultd started on network regtest")
-        # Be sure to be up to date with bitcoind
-        self.wait_for_logs(["bitcoind now synced"])
+        self.wait_for_logs(["revaultd started on network regtest",
+                            "bitcoind now synced",
+                            "JSONRPC server started"])
 
     def cleanup(self):
         self.proc.kill()


### PR DESCRIPTION
This implements the `listtransactions` RPC call, which takes a vault deposit as input and outputs:
- The deposit transaction, always as `hex` along with its reception time (`received_at`). Optionally with a `blockheight` entry if it's confirmed.
- The pre-signed transactions (unvault, cancel, both emergency) as a `psbt` until it's fully signed. Then at `hex` along with its reception time (`received_at`), ie the time our `bitcoind` noticed it was broadcast. If it's confirmed, a `blockheight` entry is present as well.
- A spend transaction, only if a spend is ongoing. (same fields as above)


Based on #55 