### PR TITLE
Revocationtxs

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -159,17 +159,29 @@ known and confirmed ([`funded`](#vault-statuses)) vault.
 | `cancel_tx`            | string | Cancel transaction to sign using the PSBT format            |
 | `emergency_unvault_tx` | string | Emergency unvault transaction to sign using the PSBT format |
 
+
 ### `revocationtxs`
 
-The PSBTs once signed must be given back to the daemon.
+Hand signed PSBTs to the daemon. The PSBT may comport multiple signatures, but the call
+will error if the signature for "our" key is not part of this set.  
+This call will not return until having fetched all the signatures for satisfying the
+transactions, and transmitted to its watchtower. See the [flows](#stakeholder-flows) for more information.  
+On error, transactions are **not stored** by any mean and the process must be retried.
 
 #### Request
 
-| Field                  | Type   | Description                                                |
-| ---------------------- | ------ | ---------------------------------------------------------- |
-| `emergency_tx`         | string | Emergency transaction signed using the PSBT format         |
-| `cancel_tx`            | string | Cancel transaction signed using the PSBT format            |
-| `emergency_unvault_tx` | string | Emergency unvault transaction signed using the PSBT format |
+| Field                  | Type   | Description                                                 |
+| ---------------------- | ------ | ----------------------------------------------------------- |
+| `cancel_tx`            | string | Cancel transaction signed using the PSBT format.            |
+| `emergency_tx`         | string | Emergency transaction signed using the PSBT format.         |
+| `unvault_emergency_tx` | string | Emergency unvault transaction signed using the PSBT format. |
+
+
+#### Response
+
+None; the `result` field will be set to the empty object `{}`. Any value should be
+disregarded for forward compatibility.
+
 
 ### `getunvaulttx`
 

--- a/src/daemon/database/interface.rs
+++ b/src/daemon/database/interface.rs
@@ -341,7 +341,7 @@ pub fn db_transactions(
 
             #[cfg(debug_assertions)]
             {
-                let db_psbt: Option<String> = row.get(3)?;
+                let db_psbt: Option<Vec<u8>> = row.get(3)?;
                 let db_tx: Option<Vec<u8>> = row.get(4)?;
                 assert!(
                     db_psbt.is_some() ^ db_tx.is_some(),
@@ -359,27 +359,27 @@ pub fn db_transactions(
                 }
                 psbt_type => {
                     // For the remaining transactions (which we do create), we store a PSBT.
-                    let tx: String = row.get(3)?;
+                    let tx: Vec<u8> = row.get(3)?;
                     match psbt_type {
                         TransactionType::Deposit => unreachable!(), // The compiler could probably catch this?
                         TransactionType::Unvault => RevaultTx::Unvault(
-                            UnvaultTransaction::from_psbt_str(&tx)
+                            UnvaultTransaction::from_psbt_serialized(&tx)
                                 .map_err(|e| FromSqlError::Other(Box::new(e)))?,
                         ),
                         TransactionType::Cancel => RevaultTx::Cancel(
-                            CancelTransaction::from_psbt_str(&tx)
+                            CancelTransaction::from_psbt_serialized(&tx)
                                 .map_err(|e| FromSqlError::Other(Box::new(e)))?,
                         ),
                         TransactionType::Emergency => RevaultTx::Emergency(
-                            EmergencyTransaction::from_psbt_str(&tx)
+                            EmergencyTransaction::from_psbt_serialized(&tx)
                                 .map_err(|e| FromSqlError::Other(Box::new(e)))?,
                         ),
                         TransactionType::UnvaultEmergency => RevaultTx::UnvaultEmergency(
-                            UnvaultEmergencyTransaction::from_psbt_str(&tx)
+                            UnvaultEmergencyTransaction::from_psbt_serialized(&tx)
                                 .map_err(|e| FromSqlError::Other(Box::new(e)))?,
                         ),
                         TransactionType::Spend => RevaultTx::Spend(
-                            SpendTransaction::from_psbt_str(&tx)
+                            SpendTransaction::from_psbt_serialized(&tx)
                                 .map_err(|e| FromSqlError::Other(Box::new(e)))?,
                         ),
                     }

--- a/src/daemon/database/interface.rs
+++ b/src/daemon/database/interface.rs
@@ -282,6 +282,22 @@ impl TryFrom<u32> for TransactionType {
     }
 }
 
+macro_rules! tx_type_from_tx {
+    ($tx:ident, $tx_type:ident) => {
+        impl From<&$tx> for TransactionType {
+            fn from(_: &$tx) -> Self {
+                Self::$tx_type
+            }
+        }
+    };
+}
+tx_type_from_tx!(VaultTransaction, Deposit);
+tx_type_from_tx!(UnvaultTransaction, Unvault);
+tx_type_from_tx!(CancelTransaction, Cancel);
+tx_type_from_tx!(EmergencyTransaction, Emergency);
+tx_type_from_tx!(UnvaultEmergencyTransaction, UnvaultEmergency);
+tx_type_from_tx!(SpendTransaction, Spend);
+
 /// A transaction stored in the 'transactions' table
 #[derive(Debug)]
 pub enum RevaultTx {

--- a/src/daemon/database/mod.rs
+++ b/src/daemon/database/mod.rs
@@ -15,4 +15,10 @@ impl std::fmt::Display for DatabaseError {
 
 impl std::error::Error for DatabaseError {}
 
+impl From<revault_tx::Error> for DatabaseError {
+    fn from(e: revault_tx::Error) -> Self {
+        Self(format!("Transaction error: {}", e))
+    }
+}
+
 pub const DB_VERSION: u32 = 0;

--- a/src/daemon/database/schema.rs
+++ b/src/daemon/database/schema.rs
@@ -37,7 +37,7 @@ CREATE TABLE transactions (
     id INTEGER PRIMARY KEY NOT NULL,
     vault_id INTEGER NOT NULL,
     type INTEGER NOT NULL,
-    psbt TEXT UNIQUE,
+    psbt BLOB UNIQUE,
     tx BLOB UNIQUE,
     FOREIGN KEY (vault_id) REFERENCES vaults (id)
         ON UPDATE RESTRICT

--- a/src/daemon/threadmessages.rs
+++ b/src/daemon/threadmessages.rs
@@ -32,6 +32,16 @@ pub enum RpcMessageIn {
             )>,
         >,
     ),
+    // Returns None if the transactions could all be stored succesfully
+    RevocationTxs(
+        (
+            OutPoint,
+            CancelTransaction,
+            EmergencyTransaction,
+            UnvaultEmergencyTransaction,
+        ),
+        SyncSender<Option<String>>,
+    ),
     ListTransactions(
         Option<Vec<OutPoint>>,
         SyncSender<


### PR DESCRIPTION
This (partially) implements the `revocationtxs` call. It's not functional yet, but the only thing left is the signature fetching from the sync server.

On top of #56 
Fixes  #57