### PR TITLE
Incremental parsing for the JSONRPC server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "revault_tx"
 version = "0.0.1"
-source = "git+https://github.com/re-vault/revault_tx#7a13866cc09e0ee7e582f5f50f7ab5d6702f3723"
+source = "git+https://github.com/re-vault/revault_tx#95fe842230f148cf2987927685c3ed300da7b56a"
 dependencies = [
  "base64",
  "bitcoinconsensus",

--- a/contrib/ci-functional-tests.sh
+++ b/contrib/ci-functional-tests.sh
@@ -21,4 +21,4 @@ cd tests/servers/coordinatord && git submodule update --init && cargo build && c
 python3 -m venv venv
 . venv/bin/activate
 pip install -r tests/requirements.txt
-TIMEOUT=120 TEST_DEBUG=1 POSTGRES_USER="test" POSTGRES_PASS="test" pytest -vvv -n2 --log-cli-level=DEBUG tests/
+TIMEOUT=120 TEST_DEBUG=1 POSTGRES_USER="test" POSTGRES_PASS="test" pytest -vvv --log-cli-level=DEBUG tests/

--- a/src/daemon/bitcoind/actions.rs
+++ b/src/daemon/bitcoind/actions.rs
@@ -20,8 +20,8 @@ use revault_tx::{
         transaction_chain, CancelTransaction, EmergencyTransaction, UnvaultEmergencyTransaction,
         UnvaultTransaction,
     },
-    txins::VaultTxIn,
-    txouts::VaultTxOut,
+    txins::DepositTxIn,
+    txouts::DepositTxOut,
 };
 
 use std::{
@@ -273,18 +273,18 @@ fn presigned_transactions(
         .ok_or_else(|| {
             BitcoindError::Custom(format!("Unknown derivation index for: {:#?}", &utxo))
         })?;
-    let deposit_descriptor = revaultd.vault_descriptor.derive(derivation_index);
+    let deposit_descriptor = revaultd.deposit_descriptor.derive(derivation_index);
     let unvault_descriptor = revaultd.unvault_descriptor.derive(derivation_index);
     let cpfp_descriptor = revaultd.cpfp_descriptor.derive(derivation_index);
     let emer_address = revaultd.emergency_address.clone(); // FIXME: should be valid for manager
 
     // Reconstruct the deposit UTXO and derive all pre-signed transactions out of it.
-    let vault_txin = VaultTxIn::new(
+    let deposit_txin = DepositTxIn::new(
         *outpoint,
-        VaultTxOut::new(utxo.txo.value, &deposit_descriptor, revaultd.xpub_ctx()),
+        DepositTxOut::new(utxo.txo.value, &deposit_descriptor, revaultd.xpub_ctx()),
     );
     let (unvault_tx, cancel_tx, emer_tx, unemer_tx) = transaction_chain(
-        vault_txin,
+        deposit_txin,
         &deposit_descriptor,
         &unvault_descriptor,
         &cpfp_descriptor,

--- a/src/daemon/control.rs
+++ b/src/daemon/control.rs
@@ -37,8 +37,8 @@ use revault_tx::{
         transaction_chain, CancelTransaction, EmergencyTransaction, RevaultTransaction,
         UnvaultEmergencyTransaction, UnvaultTransaction,
     },
-    txins::VaultTxIn,
-    txouts::VaultTxOut,
+    txins::DepositTxIn,
+    txouts::DepositTxOut,
 };
 
 use std::{
@@ -196,10 +196,10 @@ fn txlist_from_outpoints(
         // yet, ie not in DB).
         // One day, we could try to be smarter wrt free derivation but it's not
         // a priority atm.
-        let deposit_descriptor = revaultd.vault_descriptor.derive(deriv_index);
-        let vault_txin = VaultTxIn::new(
+        let deposit_descriptor = revaultd.deposit_descriptor.derive(deriv_index);
+        let vault_txin = DepositTxIn::new(
             db_vault.deposit_outpoint,
-            VaultTxOut::new(db_vault.amount.as_sat(), &deposit_descriptor, xpub_ctx),
+            DepositTxOut::new(db_vault.amount.as_sat(), &deposit_descriptor, xpub_ctx),
         );
         let unvault_descriptor = revaultd.unvault_descriptor.derive(deriv_index);
         let cpfp_descriptor = revaultd.cpfp_descriptor.derive(deriv_index);
@@ -500,10 +500,10 @@ pub fn handle_rpc_messages(
                 if let Some(vault) = vault {
                     // Second, derive the fully-specified deposit txout.
                     let deposit_descriptor =
-                        revaultd.vault_descriptor.derive(vault.derivation_index);
-                    let vault_txin = VaultTxIn::new(
+                        revaultd.deposit_descriptor.derive(vault.derivation_index);
+                    let deposit_txin = DepositTxIn::new(
                         outpoint,
-                        VaultTxOut::new(vault.amount.as_sat(), &deposit_descriptor, xpub_ctx),
+                        DepositTxOut::new(vault.amount.as_sat(), &deposit_descriptor, xpub_ctx),
                     );
 
                     // Third, re-derive all the transactions out of it.
@@ -513,7 +513,7 @@ pub fn handle_rpc_messages(
                     let emer_address = revaultd.emergency_address.clone();
 
                     let (_, cancel, emergency, unvault_emer) = transaction_chain(
-                        vault_txin,
+                        deposit_txin,
                         &deposit_descriptor,
                         &unvault_descriptor,
                         &cpfp_descriptor,

--- a/src/daemon/database/interface.rs
+++ b/src/daemon/database/interface.rs
@@ -149,7 +149,7 @@ pub fn db_wallet(db_path: &PathBuf) -> Result<DbWallet, DatabaseError> {
         Ok(DbWallet {
             id: row.get(0)?,
             timestamp: row.get(1)?,
-            vault_descriptor: row.get(2)?,
+            deposit_descriptor: row.get(2)?,
             unvault_descriptor: row.get(3)?,
             our_man_xpub,
             our_stk_xpub,

--- a/src/daemon/database/schema.rs
+++ b/src/daemon/database/schema.rs
@@ -29,7 +29,7 @@ CREATE TABLE tip (
 CREATE TABLE wallets (
     id INTEGER PRIMARY KEY NOT NULL,
     timestamp INTEGER NOT NULL,
-    vault_descriptor TEXT NOT NULL,
+    deposit_descriptor TEXT NOT NULL,
     unvault_descriptor TEXT NOT NULL,
     our_manager_xpub TEXT,
     our_stakeholder_xpub TEXT,
@@ -82,7 +82,7 @@ CREATE INDEX vault_transactions ON presigned_transactions (vault_id);
 pub struct DbWallet {
     pub id: u32,
     pub timestamp: u32,
-    pub vault_descriptor: String,
+    pub deposit_descriptor: String,
     pub unvault_descriptor: String,
     pub our_man_xpub: Option<ExtendedPubKey>,
     pub our_stk_xpub: Option<ExtendedPubKey>,

--- a/src/daemon/sigfetcher.rs
+++ b/src/daemon/sigfetcher.rs
@@ -214,6 +214,7 @@ pub fn signature_fetcher_loop(
     let mut last_poll = time::Instant::now();
     let poll_interval = revaultd.read().unwrap().coordinator_poll_interval;
 
+    log::info!("Signature fetcher thread started.");
     loop {
         // Process any message from master first
         match rx.try_recv() {

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -8,17 +8,21 @@ from utils import TIMEOUT, wait_for, RpcError, POSTGRES_IS_SETUP
 
 def test_revaultd_stakeholder_starts(revaultd_stakeholder):
     revaultd_stakeholder.rpc.call("stop")
-    revaultd_stakeholder.wait_for_log("Stopping revaultd.")
-    revaultd_stakeholder.wait_for_log("Bitcoind received shutdown.")
-    revaultd_stakeholder.wait_for_log("Signature fetcher thread received shutdown.")
+    revaultd_stakeholder.wait_for_logs([
+        "Stopping revaultd.",
+        "Bitcoind received shutdown.",
+        "Signature fetcher thread received shutdown.",
+    ])
     revaultd_stakeholder.proc.wait(TIMEOUT)
 
 
 def test_revaultd_manager_starts(revaultd_manager):
     revaultd_manager.rpc.call("stop")
-    revaultd_manager.wait_for_log("Stopping revaultd.")
-    revaultd_manager.wait_for_log("Bitcoind received shutdown.")
-    revaultd_manager.wait_for_log("Signature fetcher thread received shutdown.")
+    revaultd_manager.wait_for_logs([
+        "Stopping revaultd.",
+        "Bitcoind received shutdown.",
+        "Signature fetcher thread received shutdown.",
+    ])
     revaultd_manager.proc.wait(TIMEOUT)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -373,8 +373,6 @@ class TailableProc(object):
                     if self.is_in_log(r):
                         print("({} was previously in logs!)".format(r))
                 raise TimeoutError('Unable to find "{}" in logs.'.format(exs))
-            elif not self.running:
-                raise ValueError('Process died while waiting for logs')
 
             with self.logs_cond:
                 if pos >= len(self.logs):
@@ -390,6 +388,9 @@ class TailableProc(object):
                 if len(exs) == 0:
                     return self.logs[pos]
                 pos += 1
+
+            if not self.running:
+                raise ValueError('Process died while waiting for logs')
 
     def wait_for_log(self, regex, timeout=TIMEOUT):
         """Look for `regex` in the logs.
@@ -677,7 +678,8 @@ class Revaultd(TailableProc):
         TailableProc.start(self)
         self.wait_for_logs(["revaultd started on network regtest",
                             "bitcoind now synced",
-                            "JSONRPC server started"])
+                            "JSONRPC server started",
+                            "Signature fetcher thread started"])
 
     def cleanup(self):
         try:


### PR DESCRIPTION
This builds on top of #76 .

This implements a read cache per connection so that commands can be split across reads. While at it i also implemented a pretty naive parallelization of command handlers, as it was a pain to use the CLI at the same time as the GUI.

All of this puts some more load on us but will make the interface way more robust --at least i hope so :).