### PR TITLE
fix(jsonrpc/api): missing vault_outpoint

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -126,7 +126,7 @@ vault's state).
 
 | Field               | Type                                                           | Description                                                              |
 | ------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `outpoint`          | string                                                         | The vault deposit transaction outpoint.                                  |
+| `vault_outpoint`    | string                                                         | The vault deposit transaction outpoint.                                  |
 | `unvault`           | string                                                         | The unvaulting transaction as a base64-encoded PSBT                      |
 | `cancel`            | string                                                         | The cancel transaction as a base64-encoded PSBT                          |
 | `emergency`         | string or `null`                                               | The Emergency transaction, or `null` if we are not a stakeholder         |
@@ -154,7 +154,7 @@ network (hence they may be unconfirmed). Will error if any of the vaults is unkn
 
 | Field               | Type                                                           | Description                                                              |
 | ------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `outpoint`          | string                                                         | The vault deposit transaction outpoint.                                  |
+| `vault_outpoint`    | string                                                         | The vault deposit transaction outpoint.                                  |
 | `deposit`           | [wallet tx](#wallet-tx)                                        | The deposit transaction, always there since vault exists                 |
 | `unvault`           | [wallet tx](#wallet-tx) or `null`                              | The Unvault transaction                                                  |
 | `cancel`            | [wallet tx](#wallet-tx) or `null`                              | The Cancel transaction                                                   |

--- a/src/daemon/jsonrpc/api.rs
+++ b/src/daemon/jsonrpc/api.rs
@@ -398,6 +398,7 @@ impl RpcApi for RpcImpl {
             .into_iter()
             .map(|v| {
                 json!({
+                    "vault_outpoint": v.outpoint,
                     "unvault": v.unvault,
                     "cancel": v.cancel,
                     "emergency": v.emergency,
@@ -441,6 +442,7 @@ impl RpcApi for RpcImpl {
             .into_iter()
             .map(|v| {
                 json!({
+                    "vault_outpoint": v.outpoint,
                     "deposit": wallet_tx_to_json(v.deposit),
                     "unvault": v.unvault.map(wallet_tx_to_json),
                     "cancel": v.cancel.map(wallet_tx_to_json),


### PR DESCRIPTION
A vault can share the same deposit transaction with
an other vault. The client need to have information
about which transactions are linked to the requested
outpoint.